### PR TITLE
Add create_email_draft tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apple Mail MCP
 
-A Claude Desktop extension that gives **Claude read-only access to Apple Mail** on macOS via Mail.app's native scripting interface. No IMAP credentials, no database access, no Full Disk Access needed — just Automation permission, which macOS prompts for automatically.
+A Claude Desktop extension that gives **Claude access to Apple Mail** on macOS via Mail.app's native scripting interface. No IMAP credentials, no database access, no Full Disk Access needed — just Automation permission, which macOS prompts for automatically.
 
 Packaged as an [MCPB desktop extension](https://support.claude.com/en/articles/12922929-building-desktop-extensions-with-mcpb) with the Apple Mail icon and one-click install.
 
@@ -19,6 +19,7 @@ Packaged as an [MCPB desktop extension](https://support.claude.com/en/articles/1
 | `get_thread` | All messages in a conversation thread |
 | `list_email_attachments` | Enumerate attachments for any email |
 | `get_email_attachment` | Retrieve attachment content (base64) |
+| `create_email_draft` | Create a draft email saved to Mail.app's Drafts mailbox, returns a `message://` link to open it |
 
 ## How it works
 
@@ -97,6 +98,8 @@ Once installed, just ask Claude naturally:
 - *"What attachments are in the last email from my accountant?"*
 - *"Summarise the email thread about the contract renewal"*
 - *"Find flagged emails with PDF attachments"*
+- *"Draft a reply to John's email about the project update"*
+- *"Create a draft email to the team announcing Friday's meeting"*
 
 ---
 
@@ -155,7 +158,7 @@ Times measured against ~61K messages across 7 mailboxes. Searches without option
 
 ## Roadmap
 
-**Phase 1 — Read (current)**
+**Phase 1 — Read**
 - [x] List mailboxes and accounts
 - [x] Search emails (subject, sender, recipient, date, flags, attachments)
 - [x] Read full message body (plain text + HTML)
@@ -163,7 +166,8 @@ Times measured against ~61K messages across 7 mailboxes. Searches without option
 - [x] List and retrieve attachments
 - [x] `message://` links to open emails in Mail.app
 
-**Phase 2 — Write (planned)**
+**Phase 2 — Write (in progress)**
+- [x] Create draft emails (saved to Drafts with a `message://` link to open)
 - [ ] Mark as read / unread
 - [ ] Flag / unflag
 - [ ] Move to folder
@@ -173,7 +177,7 @@ Times measured against ~61K messages across 7 mailboxes. Searches without option
 
 ## Security & privacy
 
-- All operations are **read-only** — the server never modifies your mail.
+- Read operations never modify your mail. The only write operation is `create_email_draft`, which saves a draft locally — it does not send anything.
 - No data leaves your machine — this is a local MCP server.
 - Only requires Automation permission, not Full Disk Access.
 - macOS-only (`"platforms": ["darwin"]` in manifest).

--- a/manifest.json
+++ b/manifest.json
@@ -5,8 +5,8 @@
   "name": "apple-mail",
   "display_name": "Apple Mail",
   "version": "0.1.0",
-  "description": "Read-only access to Apple Mail on macOS — search emails, read messages, list attachments, and view threads via Mail.app's scripting interface.",
-  "long_description": "Connects Claude to Apple Mail on your Mac via Mail.app's native scripting interface. No database access or special permissions needed.\n\n**Features:**\n- Search emails by subject, sender, date range, flags, and attachments\n- Read full message bodies (plain text and HTML)\n- View email threads / conversations\n- List and retrieve attachments\n- Browse all mailboxes and accounts\n\n**Requirements:**\n- macOS 13 Ventura or later\n- Apple Mail running\n- Automation permission (macOS prompts automatically on first use)",
+  "description": "Access Apple Mail on macOS — search emails, read messages, create drafts, list attachments, and view threads via Mail.app's scripting interface.",
+  "long_description": "Connects Claude to Apple Mail on your Mac via Mail.app's native scripting interface. No database access or special permissions needed.\n\n**Features:**\n- Search emails by subject, sender, date range, flags, and attachments\n- Read full message bodies (plain text and HTML)\n- View email threads / conversations\n- List and retrieve attachments\n- Browse all mailboxes and accounts\n- Create draft emails (saved to Drafts with a link to open in Mail.app)\n\n**Requirements:**\n- macOS 13 Ventura or later\n- Apple Mail running\n- Automation permission (macOS prompts automatically on first use)",
 
   "author": {
     "name": "Brad"
@@ -38,10 +38,11 @@
     { "name": "get_email_html",    "description": "Get the HTML body of an email" },
     { "name": "get_thread",        "description": "Get all messages in a conversation thread" },
     { "name": "list_email_attachments", "description": "List all attachments for a specific email" },
-    { "name": "get_email_attachment",   "description": "Retrieve an attachment as base64-encoded data" }
+    { "name": "get_email_attachment",   "description": "Retrieve an attachment as base64-encoded data" },
+    { "name": "create_email_draft",     "description": "Create a draft email in Mail.app and return a message:// link to open it" }
   ],
 
-  "keywords": ["apple", "mail", "email", "macos", "search", "attachments", "inbox"],
+  "keywords": ["apple", "mail", "email", "macos", "search", "attachments", "inbox", "draft", "compose"],
   "license": "MIT",
 
   "compatibility": {

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
 
   "name": "apple-mail",
   "display_name": "Apple Mail",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Access Apple Mail on macOS — search emails, read messages, create drafts, list attachments, and view threads via Mail.app's scripting interface.",
   "long_description": "Connects Claude to Apple Mail on your Mac via Mail.app's native scripting interface. No database access or special permissions needed.\n\n**Features:**\n- Search emails by subject, sender, date range, flags, and attachments\n- Read full message bodies (plain text and HTML)\n- View email threads / conversations\n- List and retrieve attachments\n- Browse all mailboxes and accounts\n- Create draft emails (saved to Drafts with a link to open in Mail.app)\n\n**Requirements:**\n- macOS 13 Ventura or later\n- Apple Mail running\n- Automation permission (macOS prompts automatically on first use)",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-mail-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server for Apple Mail on macOS via Mail.app scripting"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/apple_mail_mcp/applescript.py
+++ b/src/apple_mail_mcp/applescript.py
@@ -21,6 +21,7 @@ import subprocess
 import tempfile
 import time
 from datetime import datetime
+from email.utils import parseaddr as _parseaddr
 from pathlib import Path
 from typing import Any, Optional
 
@@ -40,6 +41,12 @@ def _strip_subject_prefixes(subj: str) -> str:
         prev = subj
         subj = _RE_PREFIX.sub("", subj).strip()
     return subj
+
+
+def _parse_address(addr: str) -> tuple[str, str]:
+    """Split 'Name <email>' into (name, email). Falls back to ('', addr)."""
+    name, email = _parseaddr(addr)
+    return name or "", email or addr
 
 
 def _js_escape(value: str) -> str:
@@ -1012,6 +1019,96 @@ class MailBridge:
                 message_id,
             )
             return filename, mime_type, raw_bytes
+
+    def create_draft(
+        self,
+        *,
+        to_addresses: list[str],
+        subject: str,
+        body: str,
+        cc_addresses: list[str] | None = None,
+        bcc_addresses: list[str] | None = None,
+    ) -> dict:
+        """Create a draft email in Mail.app.
+
+        Returns:
+            {"success": bool, "message_id": str | None}
+            message_id is the RFC 2822 Message-ID for constructing a message:// link,
+            or None if Mail.app did not expose one on the saved draft.
+        """
+        safe_subject = _js_escape(subject)
+        safe_body = _js_escape(body)
+
+        def recip_js(kind: str, addrs: list[str]) -> str:
+            cls_map = {"to": "ToRecipient", "cc": "CcRecipient", "bcc": "BccRecipient"}
+            field_map = {"to": "toRecipients", "cc": "ccRecipients", "bcc": "bccRecipients"}
+            cls = cls_map[kind]
+            field = field_map[kind]
+            lines = []
+            for addr in addrs:
+                name, email = _parse_address(addr)
+                lines.append(
+                    f'mail.make({{new: "{cls}", '
+                    f'withProperties: {{address: "{_js_escape(email)}", name: "{_js_escape(name)}"}}, '
+                    f'at: draft.{field}.end}});'
+                )
+            return "\n        ".join(lines)
+
+        to_js = recip_js("to", to_addresses)
+        cc_js = recip_js("cc", cc_addresses or [])
+        bcc_js = recip_js("bcc", bcc_addresses or [])
+
+        script = f"""
+        (function() {{
+            var mail = Application("Mail");
+
+            var draft = mail.make({{
+                new: "outgoing message",
+                withProperties: {{
+                    subject: "{safe_subject}",
+                    content: "{safe_body}",
+                    visible: false
+                }}
+            }});
+
+            {to_js}
+            {cc_js}
+            {bcc_js}
+
+            draft.save();
+
+            var msgId = null;
+            try {{ msgId = draft.messageId(); }} catch(e) {{}}
+
+            if (!msgId) {{
+                var accounts = mail.accounts();
+                outer: for (var i = 0; i < accounts.length; i++) {{
+                    var mboxes = accounts[i].mailboxes();
+                    for (var j = 0; j < mboxes.length; j++) {{
+                        if (mboxes[j].name().toLowerCase().indexOf("draft") === -1) continue;
+                        try {{
+                            var candidates = mboxes[j].messages.whose({{subject: "{safe_subject}"}});
+                            var latest = null, latestDate = null;
+                            for (var k = 0; k < candidates.length; k++) {{
+                                var ds = candidates[k].dateSent() || candidates[k].dateReceived();
+                                if (ds && (!latestDate || ds > latestDate)) {{
+                                    latestDate = ds; latest = candidates[k];
+                                }}
+                            }}
+                            if (latest) {{ try {{ msgId = latest.messageId(); }} catch(e2) {{}} }}
+                        }} catch(e) {{}}
+                        if (msgId) break outer;
+                    }}
+                }}
+            }}
+
+            return JSON.stringify({{"success": true, "message_id": msgId}});
+        }})();
+        """
+        result = self._run_jxa(script, timeout=30)
+        if result is None:
+            return {"success": False, "message_id": None}
+        return result
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/src/apple_mail_mcp/applescript.py
+++ b/src/apple_mail_mcp/applescript.py
@@ -1040,7 +1040,7 @@ class MailBridge:
         safe_body = _js_escape(body)
 
         def recip_js(kind: str, addrs: list[str]) -> str:
-            cls_map = {"to": "to recipient", "cc": "cc recipient", "bcc": "bcc recipient"}
+            cls_map = {"to": "ToRecipient", "cc": "CcRecipient", "bcc": "BccRecipient"}
             field_map = {"to": "toRecipients", "cc": "ccRecipients", "bcc": "bccRecipients"}
             cls = cls_map[kind]
             field = field_map[kind]
@@ -1048,9 +1048,9 @@ class MailBridge:
             for addr in addrs:
                 name, email = _parse_address(addr)
                 lines.append(
-                    f'mail.make({{new: "{cls}", '
-                    f'withProperties: {{address: "{_js_escape(email)}", name: "{_js_escape(name)}"}}, '
-                    f'at: draft.{field}.end}});'
+                    f'draft.{field}.push('
+                    f'mail.{cls}({{address: "{_js_escape(email)}", name: "{_js_escape(name)}"}}'
+                    f'));'
                 )
             return "\n        ".join(lines)
 
@@ -1066,14 +1066,14 @@ class MailBridge:
             // pre-existing drafts with the same subject.
             var createdAfter = new Date();
 
-            var draft = mail.make({{
-                new: "outgoing message",
-                withProperties: {{
-                    subject: "{safe_subject}",
-                    content: "{safe_body}",
-                    visible: false
-                }}
+            // Use JXA constructor style — mail.make() is not supported for
+            // outgoing messages in Mail.app's JXA dictionary.
+            var draft = mail.OutgoingMessage({{
+                subject: "{safe_subject}",
+                content: "{safe_body}",
+                visible: false
             }});
+            mail.outgoingMessages.push(draft);
 
             {to_js}
             {cc_js}

--- a/src/apple_mail_mcp/applescript.py
+++ b/src/apple_mail_mcp/applescript.py
@@ -1095,16 +1095,16 @@ class MailBridge:
                         if (mboxes[j].name().toLowerCase().indexOf("draft") === -1) continue;
                         try {{
                             var candidates = mboxes[j].messages.whose({{subject: "{safe_subject}"}});
-                            var latest = null, latestDate = null;
+                            var latest = -1, latestDate = null;
                             for (var k = 0; k < candidates.length; k++) {{
-                                var ds = candidates[k].dateSent() || candidates[k].dateReceived();
-                                // Only consider drafts saved at or after our timestamp
-                                // to avoid matching pre-existing drafts with the same subject.
-                                if (ds && ds >= createdAfter && (!latestDate || ds > latestDate)) {{
-                                    latestDate = ds; latest = candidates[k];
-                                }}
+                                // Per-message try/catch: a bad message must not abort the loop.
+                                var ds = null;
+                                try {{ ds = candidates[k].dateSent(); }} catch(e) {{}}
+                                if (!ds) {{ try {{ ds = candidates[k].dateReceived(); }} catch(e) {{}} }}
+                                if (!ds || ds < createdAfter) continue;
+                                if (!latestDate || ds > latestDate) {{ latestDate = ds; latest = k; }}
                             }}
-                            if (latest) {{ try {{ msgId = latest.messageId(); }} catch(e2) {{}} }}
+                            if (latest >= 0) {{ try {{ msgId = candidates[latest].messageId(); }} catch(e2) {{}} }}
                         }} catch(e) {{}}
                         if (msgId) break outer;
                     }}

--- a/src/apple_mail_mcp/applescript.py
+++ b/src/apple_mail_mcp/applescript.py
@@ -1062,6 +1062,10 @@ class MailBridge:
         (function() {{
             var mail = Application("Mail");
 
+            // Record time before saving so the fallback search can exclude
+            // pre-existing drafts with the same subject.
+            var createdAfter = new Date();
+
             var draft = mail.make({{
                 new: "outgoing message",
                 withProperties: {{
@@ -1077,6 +1081,9 @@ class MailBridge:
 
             draft.save();
 
+            // Draft Message-IDs are typically not assigned until send; this is
+            // expected to return null in most cases, so the fallback below is
+            // the real code path.
             var msgId = null;
             try {{ msgId = draft.messageId(); }} catch(e) {{}}
 
@@ -1091,7 +1098,9 @@ class MailBridge:
                             var latest = null, latestDate = null;
                             for (var k = 0; k < candidates.length; k++) {{
                                 var ds = candidates[k].dateSent() || candidates[k].dateReceived();
-                                if (ds && (!latestDate || ds > latestDate)) {{
+                                // Only consider drafts saved at or after our timestamp
+                                // to avoid matching pre-existing drafts with the same subject.
+                                if (ds && ds >= createdAfter && (!latestDate || ds > latestDate)) {{
                                     latestDate = ds; latest = candidates[k];
                                 }}
                             }}

--- a/src/apple_mail_mcp/applescript.py
+++ b/src/apple_mail_mcp/applescript.py
@@ -1040,7 +1040,7 @@ class MailBridge:
         safe_body = _js_escape(body)
 
         def recip_js(kind: str, addrs: list[str]) -> str:
-            cls_map = {"to": "ToRecipient", "cc": "CcRecipient", "bcc": "BccRecipient"}
+            cls_map = {"to": "to recipient", "cc": "cc recipient", "bcc": "bcc recipient"}
             field_map = {"to": "toRecipients", "cc": "ccRecipients", "bcc": "bccRecipients"}
             cls = cls_map[kind]
             field = field_map[kind]

--- a/src/apple_mail_mcp/models.py
+++ b/src/apple_mail_mcp/models.py
@@ -69,3 +69,11 @@ class MailboxStats(BaseModel):
     unread_messages: int
     mailbox_count: int
     account_count: int
+
+
+class DraftResult(BaseModel):
+    subject: str
+    to_addresses: list[str]
+    cc_addresses: list[str] = []
+    bcc_addresses: list[str] = []
+    draft_link: Optional[str] = None  # message:// URL to open draft in Mail.app

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -43,6 +43,7 @@ from .emlx import get_html_body
 from .models import (
     Attachment,
     AttachmentData,
+    DraftResult,
     EmailDetail,
     EmailSummary,
     Mailbox,
@@ -76,9 +77,9 @@ _bridge: Optional[MailBridge] = None
 mcp = FastMCP(
     "Apple Mail",
     instructions=(
-        "Read-only access to Apple Mail on this Mac via Mail.app. "
+        "Access to Apple Mail on this Mac via Mail.app. "
         "You can list mailboxes, search emails, read message bodies, "
-        "list and retrieve attachments."
+        "list and retrieve attachments, and create draft emails."
     ),
 )
 
@@ -424,6 +425,51 @@ def get_email_attachment(message_id: int, attachment_index: int) -> AttachmentDa
         content_type=content_type,
         size=len(data),
         data_base64=base64.b64encode(data).decode("ascii"),
+    )
+
+
+@mcp.tool()
+def create_email_draft(
+    to: list[str],
+    subject: str,
+    body: str,
+    cc: Optional[list[str]] = None,
+    bcc: Optional[list[str]] = None,
+) -> DraftResult:
+    """Create a draft email in Mail.app and return a link to open it.
+
+    The draft is saved to the Drafts mailbox. The returned draft_link is a
+    message:// URL that opens the draft directly in Mail.app when clicked.
+
+    Args:
+        to:      Recipient addresses, e.g. ["Name <user@example.com>", "other@example.com"].
+        subject: Subject line.
+        body:    Plain-text body.
+        cc:      Optional CC addresses (same format as `to`).
+        bcc:     Optional BCC addresses (same format as `to`).
+    """
+    if not to:
+        raise ValueError("At least one recipient in `to` is required.")
+
+    bridge = _require_bridge()
+    result = bridge.create_draft(
+        to_addresses=to,
+        subject=subject,
+        body=body,
+        cc_addresses=cc,
+        bcc_addresses=bcc,
+    )
+
+    if not result.get("success"):
+        raise RuntimeError("Failed to create draft in Mail.app.")
+
+    rfc_id = result.get("message_id")
+    return DraftResult(
+        subject=subject,
+        to_addresses=to,
+        cc_addresses=cc or [],
+        bcc_addresses=bcc or [],
+        draft_link=_make_mail_link(rfc_id),
     )
 
 


### PR DESCRIPTION
## Summary

- Adds a `create_email_draft` MCP tool that saves a draft to Mail.app's Drafts mailbox via JXA scripting
- Returns a `message://` URL (`draft_link`) that opens the draft directly in Mail.app when clicked
- Supports To, CC, and BCC recipients in `"Name <email>"` or bare-address format
- Falls back gracefully (returns `draft_link: null`) if Mail.app doesn't expose the draft's RFC 2822 Message-ID

## Test plan

- [ ] Call `create_email_draft` with a To address, subject, and body — verify draft appears in Mail.app's Drafts mailbox with correct content
- [ ] Click the returned `draft_link` — verify it opens the draft compose window in Mail.app
- [ ] Test with CC and BCC arrays — verify all recipients appear in the draft
- [ ] Test with special characters in subject/body (quotes, newlines, backslashes) — verify correct escaping
- [ ] Test with `"Name <email>"` format addresses — verify name and address both populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)