### PR TITLE
Exclude .kangentic/ and kangentic.json from .mcpb builds

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -25,5 +25,9 @@ Thumbs.db
 # Claude config (not part of the extension)
 .claude/
 
+# Kangentic (local AI workflow tool — sessions can contain conversation history)
+.kangentic/
+kangentic.json
+
 # Old install script (replaced by mcpb install flow)
 install.sh


### PR DESCRIPTION
## Summary
The v0.4.0 release build pulled in `.kangentic/` (local AI session transcripts) and `kangentic.json` (kanban-board config) because `.mcpbignore` didn't list them. Both are user-local workflow files that should never ship in a public extension archive — sessions can contain conversation history, file paths, and other context.

## Verification
- Pre-fix `.mcpb`: 27 files, 404 KB, included `.kangentic/sessions/*/events.jsonl` and `kangentic.json`.
- Post-fix `.mcpb`: 16 files, 562 KB (uncompressed total), no kangentic files. Verified with `unzip -l dist/apple-mail.mcpb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)