### PR TITLE
Fix flag color off-by-one and skip disabled accounts (v0.4.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Thumbs.db
 
 # uv
 uv.lock
+.kangentic/
+.claude/settings.local.json
+kangentic.local.json

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Packaged as an [MCPB desktop extension](https://support.claude.com/en/articles/1
 | `create_email_draft` | Create a draft email saved to Mail.app's Drafts mailbox, returns a `message://` link to open it |
 | `create_email_reply_draft` | Reply to an existing message — preserves `In-Reply-To`/`References` headers so the reply threads correctly in the recipient's client |
 | `get_email_flag` | Get the flag status and color (e.g. `"orange"`) for an email |
-| `set_email_flag` | Set or remove a color flag on an email (red/orange/yellow/green/blue/purple, or null to remove). Note: gray is read-only — see [Limitations](#limitations) |
+| `set_email_flag` | Set or remove a color flag on an email (red/orange/yellow/green/blue/purple/gray, or null to remove) |
 
 ## How it works
 
@@ -189,12 +189,6 @@ Times measured against ~61K messages across 7 mailboxes. Searches without option
 - Only requires Automation permission, not Full Disk Access.
 - macOS-only (`"platforms": ["darwin"]` in manifest).
 - Attachment data is returned as base64 only when explicitly requested.
-
----
-
-## Limitations
-
-**Gray flag is read-only.** `get_email_flag` returns `"gray"` correctly for any message flagged gray via Mail.app's UI, but `set_email_flag` cannot *set* the gray flag — Mail.app's scripting API rejects writes to `flagIndex=7` with "AppleEvent handler failed". This is a Mail.app limitation, not a bug in this connector: confirmed across both AppleScript and JXA, with no scripting workaround. The other six colors (red, orange, yellow, green, blue, purple) all work for both reading and writing. To set the gray flag, use Mail.app's UI directly.
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,9 +4,9 @@
 
   "name": "apple-mail",
   "display_name": "Apple Mail",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Access Apple Mail on macOS — search emails, read messages, manage flags, create drafts, list attachments, and view threads via Mail.app's scripting interface.",
-  "long_description": "Connects Claude to Apple Mail on your Mac via Mail.app's native scripting interface. No database access or special permissions needed.\n\n**Features:**\n- Search emails by subject, sender, date range, flags, and attachments\n- Read full message bodies (plain text and HTML)\n- View email threads / conversations\n- List and retrieve attachments\n- Browse all mailboxes and accounts\n- Create draft emails (saved to Drafts with a link to open in Mail.app)\n- Reply to existing emails with proper threading headers\n- Set, change, or remove email flags (6 writable colors: red, orange, yellow, green, blue, purple; gray is readable but not writable due to a Mail.app scripting limitation)\n\n**Requirements:**\n- macOS 13 Ventura or later\n- Apple Mail running\n- Automation permission (macOS prompts automatically on first use)",
+  "long_description": "Connects Claude to Apple Mail on your Mac via Mail.app's native scripting interface. No database access or special permissions needed.\n\n**Features:**\n- Search emails by subject, sender, date range, flags, and attachments\n- Read full message bodies (plain text and HTML)\n- View email threads / conversations\n- List and retrieve attachments\n- Browse all mailboxes and accounts\n- Create draft emails (saved to Drafts with a link to open in Mail.app)\n- Reply to existing emails with proper threading headers\n- Set, change, or remove email flags (all 7 colors: red, orange, yellow, green, blue, purple, gray)\n\n**Requirements:**\n- macOS 13 Ventura or later\n- Apple Mail running\n- Automation permission (macOS prompts automatically on first use)",
 
   "author": {
     "name": "Brad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-mail-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for Apple Mail on macOS via Mail.app scripting"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/apple_mail_mcp/applescript.py
+++ b/src/apple_mail_mcp/applescript.py
@@ -33,19 +33,13 @@ logger = logging.getLogger("apple_mail_mcp.applescript")
 
 _RE_PREFIX = re.compile(r"^(Re|Fwd|Fw)\s*:\s*", re.IGNORECASE)
 
-# Flag color name → flagIndex integer (-1 = no flag, 1–7 = red … gray).
-# Reads return 1–7 for the seven Mail.app flag colors. Writes are accepted for
-# 1–6, but Mail.app's AppleScript setter rejects flagIndex=7 ("gray") with
-# "AppleEvent handler failed" — confirmed in both JXA and AppleScript, with no
-# workaround (transition through 6, post-unflag, rule action, type coercion all
-# fail the same way). Mail.app's internal -setFlagColor: would handle gray, but
-# scripting only exposes the older setter that predates the gray addition.
+# Flag color name → flagIndex integer (-1 = no flag, 0–6 = red … gray).
+# Mail.app's flagIndex property is 0-based: 0=red, 1=orange, …, 6=gray.
 _FLAG_COLOR_MAP: dict[str, int] = {
-    "red": 1, "orange": 2, "yellow": 3,
-    "green": 4, "blue": 5, "purple": 6, "gray": 7,
+    "red": 0, "orange": 1, "yellow": 2,
+    "green": 3, "blue": 4, "purple": 5, "gray": 6,
 }
 _FLAG_COLOR_ORDER = ["red", "orange", "yellow", "green", "blue", "purple", "gray"]
-_FLAG_COLOR_WRITE_BLOCKED = {"gray"}
 
 
 def _strip_subject_prefixes(subj: str) -> str:
@@ -103,6 +97,7 @@ class MailBridge:
             var accounts = mail.accounts();
             var mboxes = [];
             for (var i = 0; i < accounts.length; i++) {
+                if (!accounts[i].enabled()) continue;
                 var acctName = accounts[i].name();
                 var mbs = accounts[i].mailboxes();
                 for (var j = 0; j < mbs.length; j++) {
@@ -230,8 +225,11 @@ class MailBridge:
             var totalMessages = 0;
             var unreadMessages = 0;
             var mailboxCount = 0;
+            var enabledAccounts = 0;
 
             for (var i = 0; i < accounts.length; i++) {
+                if (!accounts[i].enabled()) continue;
+                enabledAccounts++;
                 var mboxes = accounts[i].mailboxes();
                 mailboxCount += mboxes.length;
                 for (var j = 0; j < mboxes.length; j++) {
@@ -244,7 +242,7 @@ class MailBridge:
                 "total_messages": totalMessages,
                 "unread_messages": unreadMessages,
                 "mailbox_count": mailboxCount,
-                "account_count": accounts.length
+                "account_count": enabledAccounts
             });
         })();
         """
@@ -271,6 +269,7 @@ class MailBridge:
             var accounts = mail.accounts();
             var result = [];
             for (var i = 0; i < accounts.length; i++) {
+                if (!accounts[i].enabled()) continue;
                 var acctName = accounts[i].name();
                 var mboxes = accounts[i].mailboxes();
                 for (var j = 0; j < mboxes.length; j++) {
@@ -445,6 +444,7 @@ class MailBridge:
             var scanStart = Date.now();
 
             for (var i = 0; i < accounts.length; i++) {{
+                if (!accounts[i].enabled()) continue;
                 var acctName = accounts[i].name();
                 {acct_filter}
                 var mboxes = accounts[i].mailboxes();
@@ -1104,6 +1104,7 @@ class MailBridge:
             if (!msgId) {{
                 var accounts = mail.accounts();
                 outer: for (var i = 0; i < accounts.length; i++) {{
+                    if (!accounts[i].enabled()) continue;
                     var mboxes = accounts[i].mailboxes();
                     for (var j = 0; j < mboxes.length; j++) {{
                         if (mboxes[j].name().toLowerCase().indexOf("draft") === -1) continue;
@@ -1278,6 +1279,7 @@ class MailBridge:
                 var safeSubj = subj;
                 var accts = mail.accounts();
                 outer: for (var i = 0; i < accts.length; i++) {{
+                    if (!accts[i].enabled()) continue;
                     var dmboxes = accts[i].mailboxes();
                     for (var j = 0; j < dmboxes.length; j++) {{
                         if (dmboxes[j].name().toLowerCase().indexOf("draft") === -1) continue;
@@ -1348,9 +1350,9 @@ class MailBridge:
             var msg = msgs[0];
 
             var isFlagged = msg.flaggedStatus() ? true : false;
-            // flagIndex() returns -1 when unflagged, 1-7 for colors.
-            // Fall back to isFlagged ? 1 : -1 if the property is unavailable.
-            var colorIdx = isFlagged ? 1 : -1;
+            // flagIndex() returns -1 when unflagged, 0-6 for colors.
+            // Fall back to isFlagged ? 0 : -1 if the property is unavailable.
+            var colorIdx = isFlagged ? 0 : -1;
             try {{
                 colorIdx = msg.flagIndex();
             }} catch(e) {{}}
@@ -1363,7 +1365,7 @@ class MailBridge:
 
         color_index: int = result.get("color_index", -1)
         flag_color: Optional[str] = (
-            _FLAG_COLOR_ORDER[color_index - 1] if 1 <= color_index <= 7 else None
+            _FLAG_COLOR_ORDER[color_index] if 0 <= color_index <= 6 else None
         )
         return {
             "is_flagged": bool(result.get("is_flagged", False)),
@@ -1379,18 +1381,7 @@ class MailBridge:
 
         Returns:
             {"success": bool, "is_flagged": bool}
-
-        Raises:
-            NotImplementedError: when ``flag="gray"``. Mail.app's scripting API
-                rejects flagIndex=7; see ``_FLAG_COLOR_MAP`` for details.
         """
-        if flag in _FLAG_COLOR_WRITE_BLOCKED:
-            raise NotImplementedError(
-                f"Mail.app's scripting API does not support setting the {flag!r} "
-                "flag — this is a Mail.app limitation, not a bug in this connector. "
-                "Reading the gray flag works; only writing it via AppleScript/JXA "
-                "fails. Set this flag manually via Mail's UI."
-            )
         location = self._find_message(message_id)
         if location is None:
             raise ValueError(f"Message {message_id} not found.")
@@ -1398,7 +1389,7 @@ class MailBridge:
         acct_name, mbox_name, _ = location
         safe_acct = _js_escape(acct_name)
         safe_mbox = _js_escape(mbox_name)
-        # color_index: 1-7 = set color, -1/None = unflag via flaggedStatus = false
+        # color_index: 0-6 = set color, -1/None = unflag via flaggedStatus = false
         color_index = _FLAG_COLOR_MAP[flag] if flag is not None else -1
 
         script = f"""
@@ -1416,22 +1407,22 @@ class MailBridge:
             var msg = msgs[0];
 
             var colorIdx = {color_index};
-            if (colorIdx < 1) {{
+            if (colorIdx < 0) {{
                 // Unflag: flaggedStatus = false sets flagIndex to -1
                 msg.flaggedStatus = false;
             }} else {{
-                // Set specific color via flagIndex (confirmed in JXA probe)
+                // Set specific color via flagIndex (0-based, confirmed in JXA probe)
                 try {{
                     msg.flagIndex = colorIdx;
                 }} catch(e) {{
-                    // Fallback: boolean flag (always red)
+                    // Fallback: boolean flag (always red / index 0)
                     msg.flaggedStatus = true;
                 }}
             }}
 
             var isFlagged = msg.flaggedStatus() ? true : false;
             // Read back the actual flag index so the caller knows the true resulting color.
-            var actualIdx = isFlagged ? 1 : -1;
+            var actualIdx = isFlagged ? 0 : -1;
             try {{ actualIdx = msg.flagIndex(); }} catch(e) {{}}
             return JSON.stringify({{success: true, is_flagged: isFlagged, color_index: actualIdx}});
         }})();
@@ -1473,6 +1464,7 @@ class MailBridge:
             var accounts = mail.accounts();
             {nonempty_set_js}
             for (var i = 0; i < accounts.length; i++) {{
+                if (!accounts[i].enabled()) continue;
                 var acctName = accounts[i].name();
                 var mboxes = accounts[i].mailboxes();
                 for (var j = 0; j < mboxes.length; j++) {{

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -77,10 +77,6 @@ logger = logging.getLogger("apple_mail_mcp")
 _bridge: Optional[MailBridge] = None
 
 _VALID_FLAG_COLORS = frozenset({"red", "orange", "yellow", "green", "blue", "purple", "gray"})
-# "gray" is recognized by get_email_flag (Mail.app reads flagIndex=7 fine) but
-# Mail.app's scripting API rejects writes — keep it out of the writable set so
-# set_email_flag returns a clear, actionable error instead of a low-level one.
-_WRITABLE_FLAG_COLORS = _VALID_FLAG_COLORS - {"gray"}
 
 # ---------------------------------------------------------------------------
 # FastMCP app
@@ -476,27 +472,12 @@ def set_email_flag(
     Args:
         message_id: The integer ID from search_emails results.
         flag: Flag color to set: "red", "orange", "yellow", "green", "blue",
-              or "purple". Pass null/None to remove the flag.
-
-    Note:
-        "gray" is read-only. Mail.app's scripting API rejects writes to the
-        gray flag (flagIndex=7) — this is a Mail.app limitation, not a bug
-        in this connector. ``get_email_flag`` reads gray correctly, but
-        passing ``flag="gray"`` here raises a ValueError. The user must set
-        the gray flag manually via Mail.app's UI.
+              "purple", or "gray". Pass null/None to remove the flag.
     """
     if flag is not None and flag not in _VALID_FLAG_COLORS:
         raise ValueError(
             f"Invalid flag color {flag!r}. "
             f"Choose from: {', '.join(sorted(_VALID_FLAG_COLORS))}, or null to remove."
-        )
-    if flag is not None and flag not in _WRITABLE_FLAG_COLORS:
-        raise ValueError(
-            f"Cannot set flag color {flag!r}: Mail.app's scripting API rejects "
-            f"writes to this color (known Mail.app limitation, not a bug in this "
-            f"connector). Reading {flag!r} flags works fine via get_email_flag, "
-            f"but to set this color the user must use Mail.app's UI directly. "
-            f"Writable colors: {', '.join(sorted(_WRITABLE_FLAG_COLORS))}."
         )
     bridge = _require_bridge()
     result = bridge.set_flag(message_id, flag)
@@ -506,8 +487,8 @@ def set_email_flag(
     # is the source of truth for what the user will see in Mail's UI.
     actual_color: Optional[str] = None
     color_index = result.get("color_index", -1)
-    if isinstance(color_index, int) and 1 <= color_index <= 7:
-        actual_color = _FLAG_COLOR_ORDER[color_index - 1]
+    if isinstance(color_index, int) and 0 <= color_index <= 6:
+        actual_color = _FLAG_COLOR_ORDER[color_index]
     return FlagResult(message_id=message_id, flag_color=actual_color, success=True)
 
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -322,13 +322,10 @@ def _():
 
 @test("A", "Validation / set_email_flag accepts all 7 colors and rejects others")
 def _():
-    from src.apple_mail_mcp.server import _VALID_FLAG_COLORS, _WRITABLE_FLAG_COLORS
+    from src.apple_mail_mcp.server import _VALID_FLAG_COLORS
     for c in FLAG_COLORS:
         is_in(c, _VALID_FLAG_COLORS)
     assert "pink" not in _VALID_FLAG_COLORS
-    # Writable subset excludes gray (Mail.app scripting can't set flagIndex=7).
-    assert "gray" not in _WRITABLE_FLAG_COLORS
-    assert _WRITABLE_FLAG_COLORS == _VALID_FLAG_COLORS - {"gray"}
 
 
 @test("A", "Validation / set_email_flag ValueError mentions the bad color")
@@ -550,21 +547,9 @@ def _():
     # Mail.app needs a beat to commit a flag change before the next read can
     # observe it — a 250 ms throttle isn't always enough. Use 600 ms here.
     set_read_gap = 0.6
-    # Mail.app's scripting API rejects flagIndex=7 ("gray") with "AppleEvent
-    # handler failed" — this is a Mail.app limitation, not a connector bug
-    # (see _FLAG_COLOR_MAP in applescript.py). Iterate every color: the six
-    # writable colors must round-trip; "gray" must raise NotImplementedError.
     try:
         for c in FLAG_COLORS:
             _throttle(set_read_gap)
-            if c == "gray":
-                try:
-                    BRIDGE.set_flag(FLAGGED_ID, c)
-                    raise AssertionError("Expected NotImplementedError for gray")
-                except NotImplementedError as exc:
-                    msg = str(exc).lower()
-                    assert "gray" in msg and "mail.app" in msg, str(exc)
-                continue
             r = BRIDGE.set_flag(FLAGGED_ID, c)
             eq(r["success"], True)
             _throttle(set_read_gap)
@@ -576,51 +561,7 @@ def _():
         eq(info["is_flagged"], False); is_none(info.get("flag_color"))
     finally:
         _throttle()
-        if orig != "gray":
-            BRIDGE.set_flag(FLAGGED_ID, orig)
-
-
-@test("A", "set_email_flag rejects gray with a clear, actionable error")
-def _():
-    from src.apple_mail_mcp import server
-
-    class _FakeBridge:
-        def set_flag(self, message_id, flag=None):
-            raise AssertionError("server should reject gray before calling bridge")
-
-    prev = server._bridge
-    server._bridge = _FakeBridge()
-    try:
-        try:
-            server.set_email_flag(1, "gray")
-            raise AssertionError("Expected ValueError for gray")
-        except ValueError as exc:
-            msg = str(exc).lower()
-            # Error must mention gray, name it as a Mail.app limitation, and
-            # tell the caller what to do (use Mail.app's UI / which colors work).
-            assert "gray" in msg, str(exc)
-            assert "mail.app" in msg, str(exc)
-            assert "ui" in msg or "writable" in msg, str(exc)
-    finally:
-        server._bridge = prev
-
-
-@test("A", "MailBridge.set_flag also raises NotImplementedError for gray (defense in depth)")
-def _():
-    from src.apple_mail_mcp.applescript import MailBridge, _FLAG_COLOR_WRITE_BLOCKED
-
-    class B(MailBridge):
-        def __init__(self): pass
-        def _find_message(self, mid):
-            raise AssertionError("bridge should reject gray before _find_message")
-
-    assert "gray" in _FLAG_COLOR_WRITE_BLOCKED
-    try:
-        B().set_flag(1, "gray")
-        raise AssertionError("Expected NotImplementedError")
-    except NotImplementedError as exc:
-        assert "gray" in str(exc).lower(), str(exc)
-        assert "mail.app" in str(exc).lower(), str(exc)
+        BRIDGE.set_flag(FLAGGED_ID, orig)
 
 
 @test("B", "create_email_draft creates and we can clean up a unique-subject draft")


### PR DESCRIPTION
## Summary
- **Flag color off-by-one**: Mail.app's `flagIndex` is 0-based (0=red … 6=gray) but the code used 1-based indices, causing every flag color to shift by one (e.g. requesting "red" actually set orange). The read-back logic hid the bug by subtracting 1 before mapping back to a color name, so the MCP reported success with the correct color while Mail.app showed the wrong one.
- **Gray flag now writable**: The "gray is read-only" limitation was a consequence of the same off-by-one — the old code tried `flagIndex=7` which doesn't exist. The actual gray index (6) works fine. Removed all write-blocking code, error messages, and docs for this non-existent limitation.
- **Skip disabled accounts**: `mail.accounts()` returns all accounts including disabled ones. Enumerating mailboxes on a disabled account triggers Mail.app to attempt a connection, firing phantom notifications. Added `enabled()` checks at all 7 JXA account-enumeration points.

## Test plan
- [x] Manually verified all 7 flag colors (red, orange, yellow, green, blue, purple, gray) set correctly via JXA against a live Mail.app inbox
- [x] Verified unflagging works (flagIndex returns to -1)
- [x] Confirmed `enabled()` correctly identifies disabled accounts in JXA
- [ ] Run e2e test suite (`test_e2e.py`) to verify flag round-trip tests pass with updated indices

🤖 Generated with [Claude Code](https://claude.com/claude-code)