### PR TITLE
Fix reply drafts to preserve Mail's native blockquote styling (v0.4.16)

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -31,3 +31,6 @@ kangentic.json
 
 # Old install script (replaced by mcpb install flow)
 install.sh
+
+# Dev harness — runs MailBridge directly without MCPB rebuild; not shipped.
+tools/

--- a/build.sh
+++ b/build.sh
@@ -24,8 +24,14 @@ echo ""
 mkdir -p "${OUT}"
 mcpb pack "${SCRIPT_DIR}" "${OUT}/apple-mail.mcpb"
 
+# Stamp the version into the file's Spotlight metadata so it shows in
+# Finder → Get Info → More Info: Version.
+VERSION=$(grep '^version' "${SCRIPT_DIR}/pyproject.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
+xattr -w "com.apple.metadata:kMDItemVersion" "${VERSION}" "${OUT}/apple-mail.mcpb"
+mdimport "${OUT}/apple-mail.mcpb" 2>/dev/null || true
+
 echo ""
-echo "✓ Built: ${OUT}/apple-mail.mcpb"
+echo "✓ Built: ${OUT}/apple-mail.mcpb  (v${VERSION})"
 echo ""
 echo "To install: double-click the .mcpb file, or drag it into Claude Desktop."
 echo ""

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
 
   "name": "apple-mail",
   "display_name": "Apple Mail",
-  "version": "0.4.2",
+  "version": "0.4.16",
   "description": "Access Apple Mail on macOS — search emails, read messages, manage flags, create drafts, list attachments, and view threads via Mail.app's scripting interface.",
   "long_description": "Connects Claude to Apple Mail on your Mac via Mail.app's native scripting interface. No database access or special permissions needed.\n\n**Features:**\n- Search emails by subject, sender, date range, flags, and attachments\n- Read full message bodies (plain text and HTML)\n- View email threads / conversations\n- List and retrieve attachments\n- Browse all mailboxes and accounts\n- Create draft emails (saved to Drafts with a link to open in Mail.app)\n- Reply to existing emails with proper threading headers\n- Set, change, or remove email flags (all 7 colors: red, orange, yellow, green, blue, purple, gray)\n\n**Requirements:**\n- macOS 13 Ventura or later\n- Apple Mail running\n- Automation permission (macOS prompts automatically on first use)",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-mail-mcp"
-version = "0.4.2"
+version = "0.4.16"
 description = "MCP server for Apple Mail on macOS via Mail.app scripting"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/apple_mail_mcp/applescript.py
+++ b/src/apple_mail_mcp/applescript.py
@@ -70,6 +70,53 @@ def _js_escape(value: str) -> str:
     )
 
 
+def _as_escape(value: str) -> str:
+    """Escape a Python string for safe embedding inside an AppleScript string literal.
+
+    AppleScript strings are double-quote delimited; a literal double-quote is
+    escaped by doubling it.  Backslash has no special meaning.  Literal
+    newlines are valid inside AppleScript string literals and need no escaping.
+    """
+    return value.replace('"', '""')
+
+
+def _format_quote_attribution(sender: str, date_iso: Optional[str]) -> str:
+    """Build the 'On <date>, <sender> wrote:' attribution line in Mail.app's
+    plain-text reply style.
+
+    Mail.app uses ``"On May 1, 2026, at 8:00 PM, Sender Name <addr> wrote:"``.
+    We match that format, falling back gracefully if the date is missing or
+    not parseable.
+    """
+    sender = sender or ""
+    if not date_iso:
+        return f"On (unknown date), {sender} wrote:"
+    try:
+        dt = datetime.fromisoformat(date_iso.replace("Z", "+00:00"))
+        local = dt.astimezone()
+        # %-d / %-I are GNU/BSD extensions — strip leading zeros on day/hour.
+        formatted = local.strftime("%B %-d, %Y, at %-I:%M %p")
+        return f"On {formatted}, {sender} wrote:"
+    except (ValueError, TypeError):
+        return f"On {date_iso}, {sender} wrote:"
+
+
+def _build_quoted_reply_body(user_body: str, source: dict) -> str:
+    """Compose the full reply body: user reply, blank line, attribution, blank
+    line, then the original message body verbatim.
+
+    Returns just ``user_body`` if the source's body_text is empty (nothing
+    meaningful to quote — e.g. an HTML-only message Mail couldn't extract).
+    """
+    body_text = (source.get("body_text") or "").strip("\n")
+    if not body_text:
+        return user_body
+    sender = source.get("sender") or ""
+    date_iso = source.get("date_sent")
+    attribution = _format_quote_attribution(sender, date_iso)
+    return f"{user_body}\n\n{attribution}\n\n{body_text}"
+
+
 # ---------------------------------------------------------------------------
 # MailBridge
 # ---------------------------------------------------------------------------
@@ -206,6 +253,39 @@ class MailBridge:
 
         logger.debug("JXA completed in %.1fs", elapsed)
         return parsed
+
+    def _run_applescript(self, script: str, timeout: int = 30) -> Optional[str]:
+        """Execute AppleScript via osascript, return stdout text or None on failure."""
+        logger.debug("Running AppleScript: %s ...", script[:200].replace("\n", " "))
+        t0 = time.monotonic()
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".applescript", delete=False, prefix="as_"
+            ) as f:
+                f.write(script)
+                script_path = f.name
+            try:
+                proc = subprocess.run(
+                    ["osascript", script_path],
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+            finally:
+                Path(script_path).unlink(missing_ok=True)
+        except subprocess.TimeoutExpired:
+            logger.warning("AppleScript timed out after %.1fs", time.monotonic() - t0)
+            return None
+        elapsed = time.monotonic() - t0
+        if proc.returncode != 0:
+            logger.warning(
+                "AppleScript failed (rc=%d, %.1fs): %s",
+                proc.returncode, elapsed, proc.stderr.strip(),
+            )
+            return None
+        result = proc.stdout.strip()
+        logger.debug("AppleScript completed in %.1fs: %s", elapsed, result[:100])
+        return result
 
     # ------------------------------------------------------------------
     # Public API
@@ -1144,173 +1224,362 @@ class MailBridge:
         bcc_addresses: list[str] | None = None,
         include_quoted: bool = True,
     ) -> dict:
-        """Create a reply draft to an existing message via Mail.app's native reply command.
+        """Create a reply draft with Mail's native blockquote styling preserved.
 
-        Mail.app's `reply` command sets the In-Reply-To and References headers
-        and pre-populates the recipient list and "Re: ..." subject — none of
-        which we can do reliably by constructing an OutgoingMessage from
-        scratch. The user's body is prepended to Mail's auto-generated quoted
-        block when include_quoted=True; otherwise it replaces the content.
+        Strategy:
+          1. Save user's clipboard, then put the reply body on the clipboard.
+          2. `reply with opening window` so Mail populates the compose
+             window with its native styled rich-text body (blockquote bar).
+          3. Wait for the rich-text content to populate.
+          4. `activate` Mail so the compose window is frontmost and the
+             body field is focused (cursor at top of user-reply area).
+          5. System Events keystroke Cmd+V to paste the reply body at the
+             cursor (above the blockquote). When include_quoted is False,
+             we Cmd+A first to select the entire body (including quote)
+             so Cmd+V replaces everything with just the reply body.
+          6. `save foundMsg` to commit the draft to Drafts.
+          7. Leave the compose window OPEN and foregrounded so the user
+             can review/edit/send. (The window is NOT hidden.)
+          8. Restore the user's clipboard.
+
+        REQUIRES Accessibility permission for the responsible app — for
+        production this is Claude Desktop (System Settings → Privacy &
+        Security → Accessibility → Claude Desktop). Without it, System
+        Events keystrokes are silently denied by TCC and the saved draft
+        contains only the native quote (no user body). The diagnostic
+        STATS line includes `sysevents_paste=yes/no` so failures are
+        visible in logs.
+
+        NEVER deletes anything.
 
         Returns:
             {"success": bool, "message_id": str | None, "subject": str | None,
              "to_addresses": list[str], "cc_addresses": list[str]}
-            message_id is the RFC 2822 Message-ID for the saved draft (typically
-            None until the draft is sent — same as create_draft).
         """
         location = self._find_message(message_id)
         if location is None:
             raise ValueError(f"Message {message_id} not found.")
 
         acct_name, mbox_name, _ = location
-        safe_acct = _js_escape(acct_name)
-        safe_mbox = _js_escape(mbox_name)
-        safe_body = _js_escape(body)
-        reply_all_js = "true" if reply_all else "false"
-        include_quoted_js = "true" if include_quoted else "false"
 
-        def recip_js(kind: str, addrs: list[str]) -> str:
-            cls_map = {"cc": "CcRecipient", "bcc": "BccRecipient"}
-            field_map = {"cc": "ccRecipients", "bcc": "bccRecipients"}
-            cls = cls_map[kind]
-            field = field_map[kind]
+        # Refuse to reply to a draft. Mail.app's `reply` command hangs
+        # indefinitely when given a Drafts message, requiring a Mail restart.
+        if "draft" in (mbox_name or "").lower():
+            raise ValueError(
+                f"Message {message_id} is in '{mbox_name}'. Cannot create a reply "
+                "draft from a draft message — pick a message from Inbox or another "
+                "received-mail mailbox."
+            )
+
+        safe_acct = _as_escape(acct_name)
+        safe_mbox = _as_escape(mbox_name)
+        safe_user_body = _as_escape(body)
+        include_quoted_as = "true" if include_quoted else "false"
+
+        def recip_as(kind: str, addrs: list[str]) -> str:
             lines = []
             for addr in addrs:
                 name, email = _parse_address(addr)
                 lines.append(
-                    f'draft.{field}.push('
-                    f'mail.{cls}({{address: "{_js_escape(email)}", name: "{_js_escape(name)}"}}'
-                    f'));'
+                    f'    make new {kind} recipient at end of {kind} recipients'
+                    f' of foundMsg with properties'
+                    f' {{address:"{_as_escape(email)}", name:"{_as_escape(name)}"}}'
                 )
-            return "\n        ".join(lines)
+            return "\n".join(lines)
 
-        extra_cc_js = recip_js("cc", cc_addresses or [])
-        extra_bcc_js = recip_js("bcc", bcc_addresses or [])
+        extra_cc_as = recip_as("cc", cc_addresses or [])
+        extra_bcc_as = recip_as("bcc", bcc_addresses or [])
+        reply_all_cmd = (
+            "reply srcMsg with opening window with reply to all"
+            if reply_all else
+            "reply srcMsg with opening window without reply to all"
+        )
 
-        script = f"""
-        (function() {{
-            var mail = Application("Mail");
-            var accounts = mail.accounts.whose({{name: "{safe_acct}"}});
-            if (accounts.length === 0) return JSON.stringify({{"success": false, "error": "account not found"}});
-            var acct = accounts[0];
-            var mboxes = acct.mailboxes.whose({{name: "{safe_mbox}"}});
-            if (mboxes.length === 0) return JSON.stringify({{"success": false, "error": "mailbox not found"}});
-            var mb = mboxes[0];
-            var msgs = mb.messages.whose({{id: {message_id}}});
-            if (msgs.length === 0) return JSON.stringify({{"success": false, "error": "message not found"}});
-            var src = msgs[0];
+        script = f"""tell application "Mail"
+    -- Locate source account
+    set foundAcct to missing value
+    repeat with acc in (every account)
+        try
+            if name of acc is "{safe_acct}" then
+                set foundAcct to acc
+                exit repeat
+            end if
+        end try
+    end repeat
+    if foundAcct is missing value then return "ERROR:account_not_found"
 
-            var createdAfter = new Date();
+    -- Locate source mailbox
+    set foundMbox to missing value
+    repeat with mb in (every mailbox of foundAcct)
+        try
+            if name of mb is "{safe_mbox}" then
+                set foundMbox to mb
+                exit repeat
+            end if
+        end try
+    end repeat
+    if foundMbox is missing value then return "ERROR:mailbox_not_found"
 
-            // Mail's native reply: sets In-Reply-To/References, To/Cc, and "Re:" subject.
-            mail.reply(src, {{openingWindow: false, replyToAll: {reply_all_js}}});
+    -- Locate source message by integer id. Mail.app's `whose` filter can
+    -- transiently return 0 hits while a mailbox is being re-indexed (e.g.
+    -- right after Mail restarts) — retry a few times before giving up.
+    set srcMsgList to {{}}
+    repeat 4 times
+        set srcMsgList to (every message of foundMbox whose id is {message_id})
+        if (count of srcMsgList) > 0 then exit repeat
+        delay 2
+    end repeat
+    if (count of srcMsgList) is 0 then return "ERROR:message_not_found"
+    set srcMsg to item 1 of srcMsgList
 
-            // Mail.app populates the auto-quoted body asynchronously after reply
-            // returns. ~1 s is sufficient on modern hardware.
-            delay(1.0);
+    -- Snapshot Drafts state so we can locate the saved draft after `save`.
+    -- Read-only — never deletes.
+    set srcSubj to (subject of srcMsg) as string
+    set expectedSubj to "Re: " & srcSubj
+    set existingIds to {{}}
+    repeat with acc in (every account)
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    try
+                        if name of mb contains "raft" then
+                            repeat with d in (every message of mb whose subject is expectedSubj)
+                                try
+                                    set end of existingIds to (id of d) as integer
+                                end try
+                            end repeat
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
 
-            // Find the freshly-created outgoing message: scan from the end and
-            // pick the first "Re:..." we haven't seen before by matching subject
-            // against the source message.
-            var srcSubject = "";
-            try {{ srcSubject = src.subject() || ""; }} catch(e) {{}}
-            var expectedSubject = "Re: " + srcSubject.replace(/^Re:\\s*/i, "");
-            var draft = null;
-            var outs = mail.outgoingMessages();
-            for (var k = outs.length - 1; k >= 0; k--) {{
-                try {{
-                    var s = outs[k].subject() || "";
-                    if (s === expectedSubject || s === "Re: " + srcSubject) {{
-                        draft = outs[k];
-                        break;
-                    }}
-                }} catch(e) {{}}
-            }}
-            if (!draft) return JSON.stringify({{"success": false, "error": "reply outgoing message not found"}});
+    -- Snapshot OutgoingMessage count BEFORE reply so we can pick up only the
+    -- new one (subject-match would grab stale OutgoingMessages from earlier
+    -- calls — those have no compose-window backing store and `set content`
+    -- silently no-ops on them).
+    set preOutgoingCount to count of (get outgoing messages)
 
-            // Capture the auto-populated recipients and the auto-quoted body.
-            var subj = "";
-            try {{ subj = draft.subject() || ""; }} catch(e) {{}}
-            var toAddrs = [];
-            try {{
-                var to = draft.toRecipients();
-                for (var m = 0; m < to.length; m++) {{
-                    var addr = to[m].address();
-                    var nm = to[m].name();
-                    toAddrs.push(nm ? (nm + " <" + addr + ">") : addr);
-                }}
-            }} catch(e) {{}}
-            var ccAddrs = [];
-            try {{
-                var cc = draft.ccRecipients();
-                for (var m = 0; m < cc.length; m++) {{
-                    var addr = cc[m].address();
-                    var nm = cc[m].name();
-                    ccAddrs.push(nm ? (nm + " <" + addr + ">") : addr);
-                }}
-            }} catch(e) {{}}
+    -- Save user's clipboard so we can restore at the end.
+    set savedClip to ""
+    try
+        set savedClip to (the clipboard) as string
+    end try
 
-            var quoted = "";
-            try {{ quoted = draft.content() || ""; }} catch(e) {{}}
+    -- Put the reply body on the clipboard so System Events Cmd+V can paste
+    -- it into the compose window's rich-text body without disturbing the
+    -- surrounding HTML structure (specifically the native blockquote on
+    -- the quoted original).
+    set the clipboard to "{safe_user_body}"
 
-            // Prepend user body. include_quoted=false replaces the auto-quoted block.
-            var newBody;
-            if ({include_quoted_js}) {{
-                newBody = "{safe_body}\\n\\n" + quoted;
-            }} else {{
-                newBody = "{safe_body}";
-            }}
-            try {{ draft.content = newBody; }} catch(e) {{}}
+    -- `reply with opening window`: Mail opens a compose window with the
+    -- styled rich-text body — empty user-reply area at the top, native
+    -- blockquote with the original message below, cursor parked in the
+    -- user area. This is the only path that yields the visual blockquote
+    -- bar in the saved draft.
+    {reply_all_cmd}
 
-            // Push extra cc/bcc on top of what reply pre-populated.
-            {extra_cc_js}
-            {extra_bcc_js}
+    -- Wait for the compose window to open and Mail to finish populating
+    -- the rich text body. 2.5s is enough on warm Mail.
+    delay 2.5
 
-            draft.save();
+    -- Identify the new OutgoingMessage as the LAST item.
+    set postList to get outgoing messages
+    set postOutgoingCount to count of postList
+    if postOutgoingCount is preOutgoingCount then
+        delay 1
+        set postList to get outgoing messages
+        set postOutgoingCount to count of postList
+    end if
+    if postOutgoingCount is preOutgoingCount then
+        try
+            set the clipboard to savedClip
+        end try
+        return "ERROR:reply_did_not_create_outgoing"
+    end if
+    set foundMsg to last item of postList
 
-            // Message-ID is typically null on save (only assigned at send time),
-            // so the fallback below is the real code path.
-            var msgId = null;
-            try {{ msgId = draft.messageId(); }} catch(e) {{}}
+    -- Capture the outgoing message's subject and resolved recipients.
+    set outSubj to (subject of foundMsg) as string
 
-            if (!msgId) {{
-                // Allow Mail.app a moment to commit the draft to the Drafts mailbox.
-                delay(2.0);
-                var safeSubj = subj;
-                var accts = mail.accounts();
-                outer: for (var i = 0; i < accts.length; i++) {{
-                    if (!accts[i].enabled()) continue;
-                    var dmboxes = accts[i].mailboxes();
-                    for (var j = 0; j < dmboxes.length; j++) {{
-                        if (dmboxes[j].name().toLowerCase().indexOf("draft") === -1) continue;
-                        try {{
-                            var candidates = dmboxes[j].messages.whose({{subject: safeSubj}});
-                            var latest = -1, latestDate = null;
-                            for (var c = 0; c < candidates.length; c++) {{
-                                var ds = null;
-                                try {{ ds = candidates[c].dateSent(); }} catch(e) {{}}
-                                if (!ds) {{ try {{ ds = candidates[c].dateReceived(); }} catch(e) {{}} }}
-                                if (!ds || ds < createdAfter) continue;
-                                if (!latestDate || ds > latestDate) {{ latestDate = ds; latest = c; }}
-                            }}
-                            if (latest >= 0) {{ try {{ msgId = candidates[latest].messageId(); }} catch(e2) {{}} }}
-                        }} catch(e) {{}}
-                        if (msgId) break outer;
-                    }}
-                }}
-            }}
+    set toAddrList to {{}}
+    repeat with r in (every to recipient of foundMsg)
+        try
+            set nm to (name of r) as string
+            set addr to (address of r) as string
+            if nm is not "" then
+                set end of toAddrList to (nm & " <" & addr & ">")
+            else
+                set end of toAddrList to addr
+            end if
+        end try
+    end repeat
 
-            return JSON.stringify({{
-                "success": true,
-                "message_id": msgId,
-                "subject": subj,
-                "to_addresses": toAddrs,
-                "cc_addresses": ccAddrs
-            }});
-        }})();
-        """
-        result = self._run_jxa(script, timeout=90)
-        if result is None:
+    set ccAddrList to {{}}
+    repeat with r in (every cc recipient of foundMsg)
+        try
+            set nm to (name of r) as string
+            set addr to (address of r) as string
+            if nm is not "" then
+                set end of ccAddrList to (nm & " <" & addr & ">")
+            else
+                set end of ccAddrList to addr
+            end if
+        end try
+    end repeat
+
+    -- Bring Mail (and the compose window) frontmost. The window already
+    -- comes forward when `reply with opening window` runs, but `activate`
+    -- ensures it's the focused app for System Events keystrokes.
+    activate
+
+    -- Send the paste keystrokes. REQUIRES Accessibility permission for the
+    -- responsible app; if denied, sysEventsOK ends up false and the saved
+    -- draft will have Mail's native quote but no user body.
+    set sysEventsOK to true
+    set sysEventsErr to ""
+    set includeQuoted to {include_quoted_as}
+    try
+        tell application "System Events"
+            tell process "Mail"
+                if not includeQuoted then
+                    -- Select the entire body (user-reply area + blockquote)
+                    -- so the next paste replaces everything with user body.
+                    keystroke "a" using command down
+                    delay 0.2
+                end if
+                keystroke "v" using command down
+            end tell
+        end tell
+    on error errMsg
+        set sysEventsOK to false
+        set sysEventsErr to errMsg
+    end try
+
+    -- Give Mail a moment to apply the paste before save.
+    delay 0.5
+
+{extra_cc_as}
+{extra_bcc_as}
+    save foundMsg
+
+    delay 1
+
+    -- Leave the compose window OPEN and foregrounded so the user can review,
+    -- edit, and send. The draft has already been saved to Drafts so it
+    -- persists even if the user closes the window. Re-activate Mail in
+    -- case focus drifted during save.
+    try
+        activate
+    end try
+
+    -- Restore user's clipboard.
+    try
+        set the clipboard to savedClip
+    end try
+
+    -- Locate the saved draft for the return message-id. The newly-saved
+    -- draft has the largest id among Drafts with subject=outSubj that are
+    -- NOT in our pre-snapshot.
+    set savedId to -1
+    set msgId to ""
+    repeat with acc in (every account)
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    try
+                        if name of mb contains "raft" then
+                            repeat with d in (every message of mb whose subject is outSubj)
+                                try
+                                    set dId to (id of d) as integer
+                                    set isOld to false
+                                    repeat with eid in existingIds
+                                        if (eid as integer) is dId then
+                                            set isOld to true
+                                            exit repeat
+                                        end if
+                                    end repeat
+                                    if not isOld and dId > savedId then
+                                        set savedId to dId
+                                        try
+                                            set midRaw to (message id of d) as string
+                                            if midRaw is not "" then
+                                                set msgId to midRaw
+                                            else
+                                                set msgId to ""
+                                            end if
+                                        end try
+                                    end if
+                                end try
+                            end repeat
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+
+    -- Verify threading headers on the saved draft (diagnostic).
+    set hasInReplyTo to false
+    set hasReferences to false
+    if savedId > -1 then
+        repeat with acc in (every account)
+            if hasInReplyTo and hasReferences then exit repeat
+            try
+                if enabled of acc is true then
+                    repeat with mb in (every mailbox of acc)
+                        if hasInReplyTo and hasReferences then exit repeat
+                        try
+                            if name of mb contains "raft" then
+                                set targets to (every message of mb whose id is savedId)
+                                if (count of targets) > 0 then
+                                    try
+                                        set kRef to item 1 of targets
+                                        repeat with h in (every header of kRef)
+                                            try
+                                                set hName to (name of h) as string
+                                                if hName is "In-Reply-To" then set hasInReplyTo to true
+                                                if hName is "References" then set hasReferences to true
+                                            end try
+                                        end repeat
+                                    end try
+                                end if
+                            end if
+                        end try
+                    end repeat
+                end if
+            end try
+        end repeat
+    end if
+
+    -- Diagnostic STATS line for the harness / log.
+    set inReplyToStr to "no"
+    if hasInReplyTo then set inReplyToStr to "yes"
+    set referencesStr to "no"
+    if hasReferences then set referencesStr to "yes"
+    set sysEventsStr to "yes"
+    if not sysEventsOK then set sysEventsStr to "no"
+    set statsLine to "STATS:saved=" & savedId & ¬
+        ",in_reply_to=" & inReplyToStr & ",references=" & referencesStr & ¬
+        ",pre_existing=" & (count of existingIds) & ¬
+        ",sysevents_paste=" & sysEventsStr & ¬
+        ",sysevents_err=[" & sysEventsErr & "]"
+
+    set resultStr to "OK" & linefeed & statsLine & linefeed & ¬
+        "SUBJECT:" & outSubj & linefeed & "MSGID:" & msgId
+    repeat with addr in toAddrList
+        set resultStr to resultStr & linefeed & "TO:" & addr
+    end repeat
+    repeat with addr in ccAddrList
+        set resultStr to resultStr & linefeed & "CC:" & addr
+    end repeat
+    return resultStr
+end tell"""
+
+        raw = self._run_applescript(script, timeout=90)
+        if not raw or raw.startswith("ERROR:"):
+            logger.warning("create_reply_draft AppleScript failed: %s", raw)
             return {
                 "success": False,
                 "message_id": None,
@@ -1318,6 +1587,27 @@ class MailBridge:
                 "to_addresses": [],
                 "cc_addresses": [],
             }
+
+        # Parse structured multi-line response.
+        result: dict[str, Any] = {
+            "success": True,
+            "subject": "",
+            "message_id": None,
+            "to_addresses": [],
+            "cc_addresses": [],
+        }
+        for line in raw.splitlines():
+            if line.startswith("SUBJECT:"):
+                result["subject"] = line[8:]
+            elif line.startswith("MSGID:"):
+                mid = line[6:].strip("<>")
+                result["message_id"] = mid or None
+            elif line.startswith("TO:"):
+                result["to_addresses"].append(line[3:])
+            elif line.startswith("CC:") and line[3:]:
+                result["cc_addresses"].append(line[3:])
+            elif line.startswith("STATS:"):
+                logger.info("create_reply_draft dedup %s", line[6:])
         return result
 
     def get_flag(self, message_id: int) -> dict:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -175,13 +175,16 @@ def setup() -> bool:
     # enough to find at least one of each fixture type for an active user.
     since_recent = datetime.now(timezone.utc) - timedelta(days=90)
 
-    _, flagged = BRIDGE.search_messages(is_flagged=True, limit=1)  # flags often pre-date 90d
+    # Restrict fixtures to INBOX mailboxes — searching all mailboxes can pick
+    # up Drafts (e.g. one our own reply test created), and replying to a draft
+    # message is undefined behavior in Mail.app and hangs the AppleScript.
+    _, flagged = BRIDGE.search_messages(mailbox_name="INBOX", is_flagged=True, limit=1)  # flags often pre-date 90d
     if flagged: FLAGGED_ID = flagged[0]["id"]
-    _, unflagged = BRIDGE.search_messages(is_flagged=False, since=since_recent, limit=1)
+    _, unflagged = BRIDGE.search_messages(mailbox_name="INBOX", is_flagged=False, since=since_recent, limit=1)
     if unflagged:
         UNFLAGGED_ID = unflagged[0]["id"]
         RECENT_ID = unflagged[0]["id"]   # reuse for recent
-    _, attached = BRIDGE.search_messages(has_attachments=True, since=since_recent, limit=1)
+    _, attached = BRIDGE.search_messages(mailbox_name="INBOX", has_attachments=True, since=since_recent, limit=1)
     if attached: ATTACHMENT_ID = attached[0]["id"]
     THREAD_ID = RECENT_ID  # any message id can seed a thread query
 

--- a/tools/dev_harness.py
+++ b/tools/dev_harness.py
@@ -1,0 +1,596 @@
+"""Dev harness — run create_reply_draft scenarios against the local Mail.app
+without rebuilding the .mcpb. Read-only verification (NEVER deletes).
+
+Usage:
+    python tools/dev_harness.py                    # default: all scenarios
+    python tools/dev_harness.py --scenarios quoted_simple
+    python tools/dev_harness.py --source-id 257008
+    python tools/dev_harness.py --inspect 257010   # dump one draft and exit
+    python tools/dev_harness.py --probe            # run AppleScript probes only
+    python tools/dev_harness.py --watchdog 600     # max wall-clock seconds (default 600)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+import textwrap
+import time
+import uuid
+from typing import Any, Optional
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO = os.path.dirname(_HERE)
+sys.path.insert(0, os.path.join(_REPO, "src"))
+
+
+def _install_watchdog(seconds: int) -> None:
+    """Hard SIGALRM after `seconds` so a hung Mail.app can never leave this
+    script running indefinitely. Print and exit non-zero. No bare-shell
+    `until ! pgrep` waiters anywhere — those self-match and never exit."""
+    def _bail(_signum, _frame):
+        print(f"\n!! WATCHDOG: forced exit after {seconds}s (Mail.app likely hung).",
+              file=sys.stderr, flush=True)
+        os._exit(124)
+    signal.signal(signal.SIGALRM, _bail)
+    signal.alarm(seconds)
+
+
+from apple_mail_mcp.applescript import MailBridge  # noqa: E402
+
+sys.path.insert(0, _HERE)
+from draft_inspect import (  # noqa: E402
+    find_drafts_with_subject,
+    dump,
+)
+
+
+# ----------------------------------------------------------------------
+# Scenario registry
+# ----------------------------------------------------------------------
+
+def make_scenarios(unique_token: str) -> dict[str, dict]:
+    """Build scenario kwargs. Each body embeds a unique token so we can
+    detect it later in the saved draft body."""
+    return {
+        "quoted_reply": {
+            "label": "Quoted, reply (single recipient)",
+            "kwargs": {"include_quoted": True, "reply_all": False},
+            "body": (
+                f"DEV_HARNESS_TOKEN={unique_token} scenario=quoted_reply\n"
+                "This is the test body. The original message should appear quoted below."
+            ),
+        },
+        "quoted_reply_all": {
+            "label": "Quoted, reply-all",
+            "kwargs": {"include_quoted": True, "reply_all": True},
+            "body": (
+                f"DEV_HARNESS_TOKEN={unique_token} scenario=quoted_reply_all\n"
+                "Reply-all test. Original quoted below."
+            ),
+        },
+        "no_quote_reply": {
+            "label": "No quote, reply",
+            "kwargs": {"include_quoted": False, "reply_all": False},
+            "body": (
+                f"DEV_HARNESS_TOKEN={unique_token} scenario=no_quote_reply\n"
+                "No quoted block expected."
+            ),
+        },
+        "no_quote_reply_all": {
+            "label": "No quote, reply-all",
+            "kwargs": {"include_quoted": False, "reply_all": True},
+            "body": (
+                f"DEV_HARNESS_TOKEN={unique_token} scenario=no_quote_reply_all\n"
+                "Reply-all, no quote."
+            ),
+        },
+        "with_cc": {
+            "label": "Quoted, reply + extra cc address",
+            "kwargs": {
+                "include_quoted": True,
+                "reply_all": False,
+                "cc_addresses": ["Test CC <harness-cc@example.invalid>"],
+            },
+            "body": (
+                f"DEV_HARNESS_TOKEN={unique_token} scenario=with_cc\n"
+                "This reply has an extra cc."
+            ),
+        },
+        "with_bcc": {
+            "label": "Quoted, reply + extra bcc address",
+            "kwargs": {
+                "include_quoted": True,
+                "reply_all": False,
+                "bcc_addresses": ["Test BCC <harness-bcc@example.invalid>"],
+            },
+            "body": (
+                f"DEV_HARNESS_TOKEN={unique_token} scenario=with_bcc\n"
+                "This reply has an extra bcc."
+            ),
+        },
+    }
+
+
+# ----------------------------------------------------------------------
+# Source picking
+# ----------------------------------------------------------------------
+
+def pick_source_message(bridge: MailBridge, override: Optional[int]) -> dict:
+    if override is not None:
+        msg = bridge.get_message(override)
+        if not msg:
+            raise SystemExit(f"--source-id {override} not found.")
+        return msg
+    # Pick a recent inbox message that isn't a reply, our test draft,
+    # or an artificial probe draft.
+    total, msgs = bridge.search_messages(limit=30)
+    for m in msgs:
+        subj = (m.get("subject") or "").strip()
+        if not subj:
+            continue
+        low = subj.lower()
+        if low.startswith("re:") or low.startswith("probe_") or low.startswith("dev_harness"):
+            continue
+        # Avoid our own outgoing test drafts (sender = us)
+        sender = (m.get("sender") or "").lower()
+        if "brad" in sender and "tallon" in sender:
+            continue
+        return m
+    if msgs:
+        return msgs[0]
+    raise SystemExit("No messages found in inbox.")
+
+
+# ----------------------------------------------------------------------
+# Verification
+# ----------------------------------------------------------------------
+
+def verify(scenario_name: str, expectations: dict, draft: dict, body_token: str) -> tuple[bool, list[str]]:
+    """Compare a draft dict against expectations. Returns (passed, issues)."""
+    issues: list[str] = []
+    if not draft.get("exists"):
+        return False, ["draft does not exist anymore"]
+
+    # 1. Body must contain the unique token (proves our body wasn't lost)
+    body = draft.get("body") or ""
+    if body_token not in body:
+        issues.append(f"body missing token {body_token!r} (got {len(body)} chars; first 80: {body[:80]!r})")
+
+    # 2. Quoted block expectation — look for an attribution line
+    expects_quote = expectations["kwargs"]["include_quoted"]
+    has_attribution = ("wrote:" in body.lower()) and ("on " in body.lower())
+    if expects_quote and not has_attribution:
+        issues.append("expected quoted block ('On <date>, <sender> wrote:') — attribution not found")
+    if not expects_quote and has_attribution:
+        issues.append("expected NO quote, but found attribution line")
+
+    # 3. Threading headers must always be present (proves reply linkage)
+    if not draft.get("in_reply_to"):
+        issues.append("In-Reply-To header missing — threading broken")
+    if not draft.get("references"):
+        issues.append("References header missing — threading broken")
+
+    # 4. Reply-all expectation: at least one cc OR multiple to recipients
+    if expectations["kwargs"]["reply_all"]:
+        n_cc = len(draft.get("cc") or [])
+        n_to = len(draft.get("to") or [])
+        if n_cc + n_to < 1:
+            issues.append("reply_all=True but no cc and no to recipients")
+
+    # 5. Extra cc / bcc additions are present
+    extra_cc = expectations["kwargs"].get("cc_addresses") or []
+    cc_addrs = " ; ".join(draft.get("cc") or []).lower()
+    for cc_addr in extra_cc:
+        # Match by email address part (ignore display name capitalization)
+        addr_part = cc_addr.split("<")[-1].rstrip(">").strip().lower()
+        if addr_part not in cc_addrs:
+            issues.append(f"expected cc address {addr_part!r} not found in cc {draft.get('cc')!r}")
+
+    extra_bcc = expectations["kwargs"].get("bcc_addresses") or []
+    bcc_addrs = " ; ".join(draft.get("bcc") or []).lower()
+    for bcc_addr in extra_bcc:
+        addr_part = bcc_addr.split("<")[-1].rstrip(">").strip().lower()
+        if addr_part not in bcc_addrs:
+            issues.append(f"expected bcc address {addr_part!r} not found in bcc {draft.get('bcc')!r}")
+
+    return (len(issues) == 0), issues
+
+
+# ----------------------------------------------------------------------
+# Pretty printer
+# ----------------------------------------------------------------------
+
+def print_draft(d: dict) -> None:
+    print(f"  id:          {d['id']}")
+    print(f"  exists:      {d.get('exists')}")
+    if not d.get("exists"):
+        return
+    print(f"  account:     {d.get('account')}")
+    print(f"  mailbox:     {d.get('mailbox')}")
+    print(f"  subject:     {d.get('subject')!r}")
+    print(f"  message_id:  {d.get('message_id_header')!r}")
+    print(f"  to:          {d.get('to')}")
+    print(f"  cc:          {d.get('cc')}")
+    print(f"  bcc:         {d.get('bcc')}")
+    print(f"  in_reply_to: {d.get('in_reply_to')!r}")
+    print(f"  references:  {d.get('references')!r}")
+    body = d.get("body") or ""
+    print(f"  body length: {len(body)}")
+    print(f"  body preview (first 400 chars):")
+    preview = body[:400]
+    for line in preview.splitlines() or [""]:
+        print(f"    │ {line}")
+    if len(body) > 400:
+        print(f"    │ … (truncated, {len(body) - 400} more chars)")
+    headers = d.get("headers") or []
+    print(f"  headers ({len(headers)}):")
+    for n, v in headers:
+        truncv = v if len(v) <= 120 else v[:120] + "…"
+        print(f"    {n}: {truncv}")
+
+
+# ----------------------------------------------------------------------
+# Scenario runner
+# ----------------------------------------------------------------------
+
+def run_scenario(
+    bridge: MailBridge,
+    name: str,
+    spec: dict,
+    source: dict,
+    created_ids_log: list[int],
+) -> bool:
+    print()
+    print("=" * 78)
+    print(f"Scenario: {name}  —  {spec['label']}")
+    print("=" * 78)
+    body = spec["body"]
+    kwargs = spec["kwargs"]
+    expected_subj = "Re: " + (source.get("subject") or "")
+
+    # Pre-state: count drafts matching expected subject
+    pre_ids = set(find_drafts_with_subject(bridge, expected_subj))
+    print(f"Pre-call drafts matching {expected_subj!r}: {len(pre_ids)}")
+
+    print(f"Calling create_reply_draft(message_id={source['id']}, body=<{len(body)}c>, **{kwargs})")
+    t0 = time.monotonic()
+    result = bridge.create_reply_draft(source["id"], body, **kwargs)
+    elapsed = time.monotonic() - t0
+    print(f"  elapsed: {elapsed:.1f}s")
+    print(f"  result:  {json.dumps(result, default=str)}")
+
+    # Allow a moment for any sync settling.
+    time.sleep(1.0)
+
+    # Post-state
+    post_ids = set(find_drafts_with_subject(bridge, expected_subj))
+    new_ids = sorted(post_ids - pre_ids)
+    created_ids_log.extend(new_ids)
+    print(f"Post-call drafts matching subject: {len(post_ids)}  (new this run: {new_ids})")
+
+    if not new_ids:
+        print("FAIL: no new draft was created.")
+        return False
+
+    # Inspect each new draft
+    all_pass = True
+    for did in new_ids:
+        print(f"\nDraft {did} diagnostics:")
+        d = dump(bridge, did)
+        print_draft(d)
+        body_token_match = body.split("\n", 1)[0]  # the DEV_HARNESS_TOKEN line
+        passed, issues = verify(name, spec, d, body_token_match)
+        if passed:
+            print(f"VERDICT for draft {did}: ✅ PASS")
+        else:
+            all_pass = False
+            print(f"VERDICT for draft {did}: ❌ FAIL")
+            for issue in issues:
+                print(f"  - {issue}")
+
+    if len(new_ids) != 1:
+        all_pass = False
+        print(f"VERDICT: ❌ FAIL (expected exactly 1 new draft, got {len(new_ids)})")
+
+    return all_pass
+
+
+# ----------------------------------------------------------------------
+# AppleScript probes (read-only — for ground-truth investigation)
+# ----------------------------------------------------------------------
+
+def probe_with_window(bridge: MailBridge, source_id: int) -> None:
+    """Probe `reply with opening window`. Read content & Drafts count.
+    NEVER closes the window or saves — leaves state intact for inspection."""
+    print()
+    print("=" * 78)
+    print("PROBE WW-1: After `reply ... with opening window`, content & Drafts count")
+    print("=" * 78)
+    p = bridge._run_applescript(f'''tell application "Mail"
+    set srcMsg to missing value
+    repeat with acc in (every account)
+        if srcMsg is not missing value then exit repeat
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    if srcMsg is not missing value then exit repeat
+                    try
+                        set tgts to (every message of mb whose id is {source_id})
+                        if (count of tgts) > 0 then
+                            set srcMsg to item 1 of tgts
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+    if srcMsg is missing value then return "ERROR:source_not_found"
+    set expectedSubj to "Re: " & ((subject of srcMsg) as string)
+
+    -- count Drafts BEFORE reply
+    set preCount to 0
+    repeat with acc in (every account)
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    try
+                        if name of mb contains "raft" then
+                            set preCount to preCount + (count of (every message of mb whose subject is expectedSubj))
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+
+    reply srcMsg with opening window without reply to all
+    delay 2
+
+    -- inspect OutgoingMessage
+    set foundMsg to missing value
+    repeat with m in (get outgoing messages)
+        try
+            if (subject of m) as string is expectedSubj then
+                set foundMsg to m
+                exit repeat
+            end if
+        end try
+    end repeat
+    set body1 to ""
+    if foundMsg is not missing value then
+        try
+            set body1 to (content of foundMsg) as string
+        end try
+    end if
+    set len1 to (length of body1)
+    if len1 > 400 then
+        set sample to text 1 thru 400 of body1
+    else
+        set sample to body1
+    end if
+
+    -- count Drafts AFTER reply
+    set postCount to 0
+    repeat with acc in (every account)
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    try
+                        if name of mb contains "raft" then
+                            set postCount to postCount + (count of (every message of mb whose subject is expectedSubj))
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+
+    return "PRE=" & preCount & linefeed & "POST=" & postCount & linefeed & "OUT_LEN=" & len1 & linefeed & "SAMPLE=" & sample
+end tell''', timeout=30)
+    print(p or "(no output)")
+
+
+def probe(bridge: MailBridge, source_id: int) -> None:
+    """Run small AppleScript probes to learn what the actual Mail.app
+    behavior is. Read-only investigation — does not call create_reply_draft.
+
+    NB: Probes still trigger Mail's `reply` command which auto-saves a draft.
+    They never delete it. They observe the auto-save state and then exit.
+    """
+    print()
+    print("=" * 78)
+    print("PROBE 1: After `reply ... without opening window`, what does")
+    print("         `content of foundMsg` (the OutgoingMessage) return?")
+    print("=" * 78)
+    p1 = bridge._run_applescript(f'''tell application "Mail"
+    -- find the source
+    set srcMsg to missing value
+    repeat with acc in (every account)
+        if srcMsg is not missing value then exit repeat
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    if srcMsg is not missing value then exit repeat
+                    try
+                        set tgts to (every message of mb whose id is {source_id})
+                        if (count of tgts) > 0 then
+                            set srcMsg to item 1 of tgts
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+    if srcMsg is missing value then return "ERROR:source_not_found"
+    set expectedSubj to "Re: " & ((subject of srcMsg) as string)
+    reply srcMsg without opening window without reply to all
+    delay 1
+    set foundMsg to missing value
+    repeat with m in (get outgoing messages)
+        try
+            if (subject of m) as string is expectedSubj then
+                set foundMsg to m
+                exit repeat
+            end if
+        end try
+    end repeat
+    if foundMsg is missing value then return "ERROR:no_outgoing"
+    set body1 to ""
+    try
+        set body1 to (content of foundMsg) as string
+    end try
+    set len1 to (length of body1)
+    -- prefix only first 300 chars
+    if len1 > 300 then
+        set sample to text 1 thru 300 of body1
+    else
+        set sample to body1
+    end if
+    return "LEN=" & len1 & linefeed & "SAMPLE=" & sample
+end tell''', timeout=30)
+    print(p1 or "(no output)")
+
+    print()
+    print("=" * 78)
+    print("PROBE 2: Find the just-created auto-saved Drafts entry; what is")
+    print("         its `content`?")
+    print("=" * 78)
+    # Use a fresh reply from a different (or same) source. We DON'T do another
+    # reply here to avoid stacking outgoing messages — instead, find the most
+    # recent Drafts entry whose subject matches and read its content.
+    p2 = bridge._run_applescript(f'''tell application "Mail"
+    set srcMsg to missing value
+    repeat with acc in (every account)
+        if srcMsg is not missing value then exit repeat
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    if srcMsg is not missing value then exit repeat
+                    try
+                        set tgts to (every message of mb whose id is {source_id})
+                        if (count of tgts) > 0 then
+                            set srcMsg to item 1 of tgts
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+    if srcMsg is missing value then return "ERROR:source_not_found"
+    set expectedSubj to "Re: " & ((subject of srcMsg) as string)
+    set foundDraft to missing value
+    set foundId to -1
+    repeat with acc in (every account)
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    try
+                        if name of mb contains "raft" then
+                            repeat with d in (every message of mb whose subject is expectedSubj)
+                                try
+                                    set dId to (id of d) as integer
+                                    if dId > foundId then
+                                        set foundDraft to d
+                                        set foundId to dId
+                                    end if
+                                end try
+                            end repeat
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+    if foundDraft is missing value then return "ERROR:no_draft"
+    set body2 to ""
+    try
+        set body2 to (content of foundDraft) as string
+    end try
+    set len2 to (length of body2)
+    if len2 > 300 then
+        set sample2 to text 1 thru 300 of body2
+    else
+        set sample2 to body2
+    end if
+    return "DRAFT_ID=" & foundId & linefeed & "LEN=" & len2 & linefeed & "SAMPLE=" & sample2
+end tell''', timeout=30)
+    print(p2 or "(no output)")
+
+
+# ----------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--source-id", type=int, default=None)
+    p.add_argument("--scenarios",
+                   default="quoted_reply,no_quote_reply,quoted_reply_all,no_quote_reply_all,with_cc,with_bcc")
+    p.add_argument("--inspect", type=int, default=None,
+                   help="Just dump diagnostics for a specific draft id, then exit.")
+    p.add_argument("--probe", action="store_true",
+                   help="Run read-only AppleScript probes only.")
+    p.add_argument("--watchdog", type=int, default=600,
+                   help="Max wall-clock seconds before SIGALRM force-exit (default 600).")
+    args = p.parse_args()
+
+    _install_watchdog(args.watchdog)
+
+    import logging
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    bridge = MailBridge()
+
+    if args.inspect:
+        d = dump(bridge, args.inspect)
+        print(json.dumps(d, indent=2, default=str))
+        return 0
+
+    source = pick_source_message(bridge, args.source_id)
+    print(f"Source message:")
+    print(f"  id={source.get('id')}  account={source.get('account')}  mailbox={source.get('mailbox')}")
+    print(f"  subject={source.get('subject')!r}")
+    print(f"  sender={source.get('sender')!r}")
+
+    if args.probe:
+        probe(bridge, source["id"])
+        probe_with_window(bridge, source["id"])
+        return 0
+
+    token = uuid.uuid4().hex[:8]
+    scenarios = make_scenarios(token)
+
+    requested = [s.strip() for s in args.scenarios.split(",") if s.strip()]
+    unknown = [s for s in requested if s not in scenarios]
+    if unknown:
+        print(f"Unknown scenario(s): {unknown}. Available: {list(scenarios)}")
+        return 2
+
+    created_ids: list[int] = []
+    results: dict[str, bool] = {}
+
+    for name in requested:
+        passed = run_scenario(bridge, name, scenarios[name], source, created_ids)
+        results[name] = passed
+        # gentle throttle between scenarios
+        time.sleep(1.0)
+
+    print()
+    print("=" * 78)
+    print("SUMMARY")
+    print("=" * 78)
+    for name, ok in results.items():
+        print(f"  {'✅' if ok else '❌'} {name}")
+    print()
+    print(f"Drafts created during this run (NOT deleted — clean up via Mail UI):")
+    for did in created_ids:
+        print(f"  - {did}")
+
+    return 0 if all(results.values()) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/draft_inspect.py
+++ b/tools/draft_inspect.py
@@ -1,0 +1,276 @@
+"""Inspection helpers for debugging Mail.app drafts via AppleScript.
+
+Each helper makes a small targeted AppleScript call. Multi-line content
+(message body) is written to a temp file by AppleScript and read back from
+Python — sidesteps any newline-parsing problems.
+
+Read-only. Never mutates Mail state.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from typing import Optional
+
+# Make the package importable when running directly from repo root.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO = os.path.dirname(_HERE)
+_SRC = os.path.join(_REPO, "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from apple_mail_mcp.applescript import MailBridge, _as_escape  # noqa: E402
+
+
+def find_drafts_with_subject(bridge: MailBridge, subject: str) -> list[int]:
+    """Return all draft IDs (across all accounts' Drafts mailboxes) whose
+    subject equals `subject`. Empty list if none."""
+    safe = _as_escape(subject)
+    script = f'''tell application "Mail"
+    set out to ""
+    repeat with acc in (every account)
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    try
+                        if name of mb contains "raft" then
+                            repeat with d in (every message of mb whose subject is "{safe}")
+                                try
+                                    set out to out & ((id of d) as string) & linefeed
+                                end try
+                            end repeat
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+    return out
+end tell'''
+    raw = bridge._run_applescript(script, timeout=20) or ""
+    ids = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if line and line.isdigit():
+            ids.append(int(line))
+    return ids
+
+
+def get_subject(bridge: MailBridge, msg_id: int) -> Optional[str]:
+    return _get_str_field(bridge, msg_id, "subject of foundMsg")
+
+
+def get_message_id_header(bridge: MailBridge, msg_id: int) -> Optional[str]:
+    return _get_str_field(bridge, msg_id, "message id of foundMsg")
+
+
+def get_account_and_mailbox(bridge: MailBridge, msg_id: int) -> Optional[tuple[str, str]]:
+    """Return (account_name, mailbox_name) for the message, or None."""
+    script = _wrap_find_msg(msg_id, '''
+    set out to ""
+    try
+        set out to (name of (mailbox of foundMsg)) as string
+    end try
+    set out2 to ""
+    try
+        set out2 to (name of (account of (mailbox of foundMsg))) as string
+    end try
+    return out2 & "<<<>>>" & out''')
+    raw = bridge._run_applescript(script, timeout=20)
+    if not raw or "<<<>>>" not in raw:
+        return None
+    acct, mbox = raw.split("<<<>>>", 1)
+    return (acct.strip(), mbox.strip())
+
+
+def get_recipients(bridge: MailBridge, msg_id: int, kind: str) -> list[str]:
+    """kind ∈ {'to', 'cc', 'bcc'}. Returns ['Name <addr>', ...]."""
+    assert kind in ("to", "cc", "bcc")
+    script = _wrap_find_msg(msg_id, f'''
+    set out to ""
+    try
+        repeat with r in (every {kind} recipient of foundMsg)
+            try
+                set nm to (name of r) as string
+            on error
+                set nm to ""
+            end try
+            try
+                set ad to (address of r) as string
+            on error
+                set ad to ""
+            end try
+            if nm is not "" then
+                set out to out & nm & " <" & ad & ">" & linefeed
+            else
+                set out to out & ad & linefeed
+            end if
+        end repeat
+    end try
+    return out''')
+    raw = bridge._run_applescript(script, timeout=20) or ""
+    return [ln for ln in (l.strip() for l in raw.splitlines()) if ln]
+
+
+def get_headers(bridge: MailBridge, msg_id: int) -> list[tuple[str, str]]:
+    """Return list of (header_name, header_value) for the message.
+    Uses '<<<:>>>' as the separator (very unlikely in real header content)."""
+    script = _wrap_find_msg(msg_id, '''
+    set out to ""
+    try
+        repeat with h in (every header of foundMsg)
+            try
+                set nm to (name of h) as string
+            on error
+                set nm to ""
+            end try
+            try
+                set ct to (content of h) as string
+            on error
+                set ct to ""
+            end try
+            set out to out & nm & "<<<:>>>" & ct & linefeed
+        end repeat
+    end try
+    return out''')
+    raw = bridge._run_applescript(script, timeout=20) or ""
+    headers = []
+    for line in raw.splitlines():
+        if "<<<:>>>" in line:
+            name, val = line.split("<<<:>>>", 1)
+            headers.append((name.strip(), val.strip()))
+    return headers
+
+
+def get_body(bridge: MailBridge, msg_id: int) -> Optional[str]:
+    """Return the full body content of the message. Uses a temp file to avoid
+    string-marshalling issues with multi-line content."""
+    fd, tmp_path = tempfile.mkstemp(prefix="mail_body_", suffix=".txt")
+    os.close(fd)
+    safe_path = tmp_path.replace('"', '\\"')
+    script = _wrap_find_msg(msg_id, f'''
+    try
+        set bodyText to (content of foundMsg) as string
+    on error
+        set bodyText to ""
+    end try
+    set fileRef to open for access POSIX file "{safe_path}" with write permission
+    set eof of fileRef to 0
+    try
+        write bodyText as «class utf8» to fileRef
+    on error
+        try
+            write bodyText to fileRef
+        end try
+    end try
+    close access fileRef
+    return "OK"''')
+    result = bridge._run_applescript(script, timeout=30)
+    body = None
+    if result == "OK":
+        try:
+            with open(tmp_path, "rb") as f:
+                raw = f.read()
+            body = raw.decode("utf-8", errors="replace")
+        except OSError:
+            body = None
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    return body
+
+
+def msg_exists(bridge: MailBridge, msg_id: int) -> bool:
+    """Quick check: does a message with this id exist anywhere?"""
+    script = f'''tell application "Mail"
+    set found to false
+    repeat with acc in (every account)
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    try
+                        if (count of (every message of mb whose id is {msg_id})) > 0 then
+                            set found to true
+                            exit repeat
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+        if found then exit repeat
+    end repeat
+    if found then
+        return "yes"
+    else
+        return "no"
+    end if
+end tell'''
+    return (bridge._run_applescript(script, timeout=15) or "").strip() == "yes"
+
+
+# --- internal helpers ---
+
+def _wrap_find_msg(msg_id: int, body: str) -> str:
+    """Wrap a snippet that uses `foundMsg` as the message reference."""
+    return f'''tell application "Mail"
+    set foundMsg to missing value
+    repeat with acc in (every account)
+        if foundMsg is not missing value then exit repeat
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    if foundMsg is not missing value then exit repeat
+                    try
+                        set tgts to (every message of mb whose id is {msg_id})
+                        if (count of tgts) > 0 then
+                            set foundMsg to item 1 of tgts
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+    if foundMsg is missing value then return ""
+{body}
+end tell'''
+
+
+def _get_str_field(bridge: MailBridge, msg_id: int, prop_expr: str) -> Optional[str]:
+    """Helper: get a single string-valued property as `prop_expr` (e.g.
+    'subject of foundMsg'). Returns None if not found / property missing."""
+    script = _wrap_find_msg(msg_id, f'''
+    set out to ""
+    try
+        set out to ({prop_expr}) as string
+    end try
+    return out''')
+    raw = bridge._run_applescript(script, timeout=15)
+    if raw is None:
+        return None
+    raw = raw.strip()
+    return raw or None
+
+
+def dump(bridge: MailBridge, msg_id: int) -> dict:
+    """Return a dict with all interesting fields of the draft."""
+    if not msg_exists(bridge, msg_id):
+        return {"id": msg_id, "exists": False}
+    acct_mbox = get_account_and_mailbox(bridge, msg_id)
+    headers = get_headers(bridge, msg_id)
+    return {
+        "id": msg_id,
+        "exists": True,
+        "subject": get_subject(bridge, msg_id),
+        "message_id_header": get_message_id_header(bridge, msg_id),
+        "account": acct_mbox[0] if acct_mbox else None,
+        "mailbox": acct_mbox[1] if acct_mbox else None,
+        "to": get_recipients(bridge, msg_id, "to"),
+        "cc": get_recipients(bridge, msg_id, "cc"),
+        "bcc": get_recipients(bridge, msg_id, "bcc"),
+        "headers": headers,
+        "in_reply_to": next((v for n, v in headers if n.lower() == "in-reply-to"), None),
+        "references": next((v for n, v in headers if n.lower() == "references"), None),
+        "body": get_body(bridge, msg_id),
+    }

--- a/tools/probe_autosave_timing.py
+++ b/tools/probe_autosave_timing.py
@@ -1,0 +1,127 @@
+"""Probe: how long does Mail.app's auto-save take after `reply` to materialize
+in Drafts? Single AppleScript invocation polls every 0.5s up to 15s, returns
+the time-to-appear and the content length."""
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import time
+
+
+def _watchdog(seconds: int = 180) -> None:
+    def _bail(_s, _f):
+        print(f"!! WATCHDOG: forced exit after {seconds}s.", file=sys.stderr, flush=True)
+        os._exit(124)
+    signal.signal(signal.SIGALRM, _bail)
+    signal.alarm(seconds)
+
+
+_watchdog(180)
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO = os.path.dirname(_HERE)
+sys.path.insert(0, os.path.join(_REPO, "src"))
+sys.path.insert(0, _HERE)
+
+from apple_mail_mcp.applescript import MailBridge  # noqa: E402
+from draft_inspect import find_drafts_with_subject  # noqa: E402
+
+
+def main() -> int:
+    bridge = MailBridge()
+    total, msgs = bridge.search_messages(limit=20)
+    src = next(
+        (m for m in msgs if (m.get("subject") or "").strip() and not (m.get("subject") or "").lower().startswith("re:")),
+        msgs[0],
+    )
+    src_id = src["id"]
+    print(f"Source: id={src_id}  subject={src.get('subject')!r}")
+    expected_subj = "Re: " + (src.get("subject") or "")
+    pre_ids = sorted(find_drafts_with_subject(bridge, expected_subj))
+    print(f"Pre-existing drafts matching subject: {len(pre_ids)}")
+
+    # Single AppleScript: reply, then poll Drafts every 0.5s for up to 15s,
+    # report when a NEW draft (id not in pre snapshot) first appears AND
+    # has non-empty content.
+    pre_ids_list = ", ".join(str(i) for i in pre_ids) or "0"
+    script = f'''tell application "Mail"
+    set existingIds to {{{pre_ids_list}}}
+    set srcMsg to missing value
+    repeat with acc in (every account)
+        if srcMsg is not missing value then exit repeat
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    if srcMsg is not missing value then exit repeat
+                    try
+                        set tgts to (every message of mb whose id is {src_id})
+                        if (count of tgts) > 0 then
+                            set srcMsg to item 1 of tgts
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+    if srcMsg is missing value then return "ERROR:src_not_found"
+    set expectedSubj to "Re: " & ((subject of srcMsg) as string)
+    set t0 to (current date)
+
+    reply srcMsg without opening window without reply to all
+
+    set log to ""
+    repeat 30 times
+        set elapsed to ((current date) - t0)
+        set foundId to -1
+        set foundLen to 0
+        repeat with acc in (every account)
+            if foundId is not -1 then exit repeat
+            try
+                if enabled of acc is true then
+                    repeat with mb in (every mailbox of acc)
+                        if foundId is not -1 then exit repeat
+                        try
+                            if name of mb contains "raft" then
+                                repeat with d in (every message of mb whose subject is expectedSubj)
+                                    try
+                                        set dId to (id of d) as integer
+                                        set isOld to false
+                                        repeat with eid in existingIds
+                                            if (eid as integer) is dId then
+                                                set isOld to true
+                                                exit repeat
+                                            end if
+                                        end repeat
+                                        if not isOld then
+                                            set foundId to dId
+                                            try
+                                                set foundLen to length of ((content of d) as string)
+                                            end try
+                                            exit repeat
+                                        end if
+                                    end try
+                                end repeat
+                            end if
+                        end try
+                    end repeat
+                end if
+            end try
+        end repeat
+        set log to log & "t=" & elapsed & "s id=" & foundId & " len=" & foundLen & linefeed
+        if foundId > -1 and foundLen > 100 then
+            return log & "DONE:t=" & elapsed & "s id=" & foundId & " len=" & foundLen
+        end if
+        delay 0.5
+    end repeat
+    return log & "TIMEOUT_AFTER_15s"
+end tell'''
+    print()
+    print("Polling Drafts (every 0.5s for up to 15s) for the auto-save to appear with content >100 chars...")
+    out = bridge._run_applescript(script, timeout=30)
+    print(out or "(no output)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/probe_strategies.py
+++ b/tools/probe_strategies.py
@@ -1,0 +1,228 @@
+"""Test 3 candidate strategies for create_reply_draft, then report which
+saves a draft with our exact body content.
+
+Read-only on existing drafts. Creates 3 test drafts (one per strategy).
+Never deletes anything.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import time
+
+
+def _watchdog(seconds: int = 300) -> None:
+    def _bail(_s, _f):
+        print(f"!! WATCHDOG: forced exit after {seconds}s.", file=sys.stderr, flush=True)
+        os._exit(124)
+    signal.signal(signal.SIGALRM, _bail)
+    signal.alarm(seconds)
+
+
+_watchdog(300)
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO = os.path.dirname(_HERE)
+sys.path.insert(0, os.path.join(_REPO, "src"))
+sys.path.insert(0, _HERE)
+
+from apple_mail_mcp.applescript import MailBridge  # noqa: E402
+from draft_inspect import find_drafts_with_subject, dump  # noqa: E402
+
+
+def pick_source(bridge: MailBridge) -> dict:
+    total, msgs = bridge.search_messages(limit=20)
+    for m in msgs:
+        s = (m.get("subject") or "").strip()
+        if s and not s.lower().startswith("re:"):
+            return m
+    return msgs[0]
+
+
+def run_strategy(bridge: MailBridge, label: str, script: str) -> dict:
+    print()
+    print("=" * 78)
+    print(f"STRATEGY: {label}")
+    print("=" * 78)
+    t0 = time.monotonic()
+    out = bridge._run_applescript(script, timeout=45)
+    elapsed = time.monotonic() - t0
+    print(f"  elapsed: {elapsed:.1f}s")
+    print(f"  AppleScript output:")
+    for line in (out or "(none)").splitlines():
+        print(f"    | {line}")
+    return {"output": out, "elapsed": elapsed}
+
+
+def main() -> int:
+    bridge = MailBridge()
+    src = pick_source(bridge)
+    print(f"Source: id={src['id']}  subject={src.get('subject')!r}")
+    src_id = src["id"]
+    expected_subj = "Re: " + (src.get("subject") or "")
+    pre_ids = set(find_drafts_with_subject(bridge, expected_subj))
+    print(f"Pre-existing drafts matching expected subject: {len(pre_ids)}")
+
+    # Strategy A: reply WITHOUT window, set content, save
+    marker_a = f"PROBE_A_{int(time.time())}"
+    script_a = f'''tell application "Mail"
+    set srcMsg to missing value
+    repeat with acc in (every account)
+        if srcMsg is not missing value then exit repeat
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    if srcMsg is not missing value then exit repeat
+                    try
+                        set tgts to (every message of mb whose id is {src_id})
+                        if (count of tgts) > 0 then
+                            set srcMsg to item 1 of tgts
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+    if srcMsg is missing value then return "ERROR:src"
+
+    -- Snapshot OutgoingMessage count
+    set preCount to count of (get outgoing messages)
+
+    reply srcMsg without opening window without reply to all
+    delay 1
+
+    set postList to get outgoing messages
+    set postCount to count of postList
+    if postCount is preCount then return "ERROR:no_new_outgoing"
+    set foundMsg to last item of postList
+
+    set content of foundMsg to "{marker_a} body"
+    save foundMsg
+
+    return "SUCCESS:new_outgoing_count_delta=" & (postCount - preCount)
+end tell'''
+    res_a = run_strategy(bridge, "A: reply WITHOUT window + set content + save", script_a)
+    time.sleep(2.0)
+
+    # Strategy B: reply WITH window + set visible false + set content + save
+    marker_b = f"PROBE_B_{int(time.time())}"
+    script_b = f'''tell application "Mail"
+    set srcMsg to missing value
+    repeat with acc in (every account)
+        if srcMsg is not missing value then exit repeat
+        try
+            if enabled of acc is true then
+                repeat with mb in (every mailbox of acc)
+                    if srcMsg is not missing value then exit repeat
+                    try
+                        set tgts to (every message of mb whose id is {src_id})
+                        if (count of tgts) > 0 then
+                            set srcMsg to item 1 of tgts
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+    end repeat
+    if srcMsg is missing value then return "ERROR:src"
+
+    set preCount to count of (get outgoing messages)
+    reply srcMsg with opening window without reply to all
+    delay 0.4
+
+    set postList to get outgoing messages
+    if (count of postList) is preCount then return "ERROR:no_new_outgoing"
+    set foundMsg to last item of postList
+
+    -- Hide ASAP
+    try
+        set visible of foundMsg to false
+    end try
+
+    -- Capture Mail's auto-generated quoted block
+    set qb to ""
+    try
+        set qb to (content of foundMsg) as string
+    end try
+    set qbLen to length of qb
+
+    set content of foundMsg to "{marker_b} body"
+    save foundMsg
+
+    return "SUCCESS:auto_quote_len=" & qbLen
+end tell'''
+    res_b = run_strategy(bridge, "B: reply WITH window + visible=false + set + save", script_b)
+    time.sleep(2.0)
+
+    # Strategy C: make new outgoing message with properties (no reply — no threading)
+    marker_c = f"PROBE_C_{int(time.time())}"
+    script_c = f'''tell application "Mail"
+    set newMsg to make new outgoing message with properties {{visible:false, subject:"PROBE_C_test", content:"{marker_c} body"}}
+    save newMsg
+    return "SUCCESS:made_outgoing_message"
+end tell'''
+    res_c = run_strategy(bridge, "C: make new outgoing message + save (NO threading)", script_c)
+    time.sleep(2.0)
+
+    # Now identify the new drafts and inspect them
+    print()
+    print("=" * 78)
+    print("INSPECTING NEW DRAFTS")
+    print("=" * 78)
+    post_ids = set(find_drafts_with_subject(bridge, expected_subj))
+    new_for_subject = sorted(post_ids - pre_ids)
+    # Also find the strategy-C draft (different subject)
+    c_ids = find_drafts_with_subject(bridge, "PROBE_C_test")
+
+    findings = {}
+    for did in new_for_subject:
+        d = dump(bridge, did)
+        body = d.get("body") or ""
+        contains_a = marker_a in body
+        contains_b = marker_b in body
+        findings[did] = {
+            "exists": d.get("exists"),
+            "body_len": len(body),
+            "body_first_300": body[:300],
+            "contains_marker_a": contains_a,
+            "contains_marker_b": contains_b,
+            "in_reply_to": d.get("in_reply_to"),
+            "has_quote_attribution": ("wrote:" in body.lower() and "on " in body.lower()),
+        }
+        print(f"\nDraft id={did}  subject={d.get('subject')!r}")
+        print(f"  body_len:               {findings[did]['body_len']}")
+        print(f"  contains marker A?      {contains_a}")
+        print(f"  contains marker B?      {contains_b}")
+        print(f"  in_reply_to set?        {bool(findings[did]['in_reply_to'])}")
+        print(f"  has quote attribution?  {findings[did]['has_quote_attribution']}")
+        print(f"  body first 300:")
+        for line in body[:300].splitlines() or [""]:
+            print(f"    │ {line}")
+
+    for did in c_ids:
+        d = dump(bridge, did)
+        body = d.get("body") or ""
+        contains_c = marker_c in body
+        print(f"\nDraft id={did}  subject={d.get('subject')!r}")
+        print(f"  body_len:               {len(body)}")
+        print(f"  contains marker C?      {contains_c}")
+        print(f"  body first 200:")
+        for line in body[:200].splitlines() or [""]:
+            print(f"    │ {line}")
+
+    print()
+    print("=" * 78)
+    print("VERDICT")
+    print("=" * 78)
+    a_works = any(f["contains_marker_a"] for f in findings.values())
+    b_works = any(f["contains_marker_b"] for f in findings.values())
+    print(f"  Strategy A (without window):           {'✅ WORKS' if a_works else '❌ FAILS'}")
+    print(f"  Strategy B (with window, hidden):      {'✅ WORKS' if b_works else '❌ FAILS'}")
+    print(f"  Strategy C (make new outgoing):        ran (check threading manually)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes `create_email_reply_draft` so the saved draft has Mail.app's **native blockquote-styled quote** (left bar, indentation), instead of running plain text together with no visual quote indicator.

The compose window is now opened, the reply text is pasted into it via System Events, and the window is **left open and foregrounded** so you can review/edit/send manually.

## What was wrong

Mail.app's `content` property on an OutgoingMessage is plain-text-only. Every previous attempt to assemble the reply by calling `set content of foundMsg to <user body + quote>` discarded the HTML/styled structure Mail had populated in the compose window — leaving a saved draft where the original message text ran inline with no visual distinction from the user's reply.

## What changed

- `reply ... with opening window` so Mail populates the compose window with its native styled quote (HTML, attachments, attribution line in user's locale).
- Reply body goes through the **clipboard + System Events Cmd+V**, which inserts text at the cursor without touching the surrounding HTML structure. `<blockquote>` stays intact.
- For `include_quoted=False`, we Cmd+A first so Cmd+V replaces the entire body (Mail's auto-quote included).
- Compose window stays open, foregrounded — caller reviews and sends. Draft is also saved to Drafts as a safety net.
- Caller's clipboard is captured before and restored after.

## New permission requirement

Sending keystrokes via System Events requires **Accessibility** permission for the host app (Claude Desktop). macOS prompts on first use; one-time grant.

## Other fixes in this PR

- **Defensive guard**: refuse to call `reply` on a Drafts-mailbox message — Mail.app hangs indefinitely on that, requiring a force-quit.
- **e2e test fixture**: restrict source picker to `INBOX` so a previously-saved test draft can't get selected as the reply source (which used to trigger the Drafts hang above).
- **Finder version display**: build script stamps `kMDItemVersion` on the `.mcpb` so right-click → Get Info shows the version.
- **Dev harness**: `tools/dev_harness.py` + helpers — exercises `MailBridge` directly against Mail.app, no MCPB rebuild loop. Excluded from the shipped extension via `.mcpbignore`.

## Test plan

- [x] `python tools/dev_harness.py` — 6 scenarios: quoted/no-quote × reply/reply-all + with_cc + with_bcc, all green
- [x] Verified threading headers (In-Reply-To / References) preserved on the saved draft
- [x] Verified compose window opens, paste lands above quote, native left-bar styling visible
- [x] Verified compose window stays open and foregrounded after the call
- [x] Verified clipboard restore after the call
- [x] Tested cold-start Mail (after restart) — message lookup retries handle re-indexing window
- [ ] Manual smoke test in Claude Desktop after merge + install